### PR TITLE
Define Fidelity spaces for benchmarks as ConfigurationSpace objects

### DIFF
--- a/examples/container/xgboost_with_container.py
+++ b/examples/container/xgboost_with_container.py
@@ -48,9 +48,15 @@ def run_experiment(on_travis: bool = False):
             print(configuration)
             for n_estimator in [8, 64]:
                 for subsample in [0.4, 1]:
+                    # Old API ---- NO LONGER SUPPORTED ---- This will simply ignore the fidelities
+                    # result_dict = b.objective_function(configuration.get_dictionary(),
+                    #                                    n_estimators=n_estimator,
+                    #                                    subsample=subsample)
+                    
+                    # New API ---- Use this
+                    fidelity = {"n_estimators": n_estimators, "subsample": subsample}
                     result_dict = b.objective_function(configuration.get_dictionary(),
-                                                       n_estimators=n_estimator,
-                                                       subsample=subsample)
+                                                       fidelity=fidelity)
                     valid_loss = result_dict['function_value']
                     train_loss = result_dict['train_loss']
 

--- a/examples/local/xgboost_local.py
+++ b/examples/local/xgboost_local.py
@@ -34,8 +34,15 @@ def run_experiment(on_travis: bool = False):
             print(configuration)
             for n_estimator in [8, 64]:
                 for subsample in [0.4, 1]:
+                    # Old API ---- NO LONGER SUPPORTED ---- This will simply ignore the fidelities
+                    # result_dict = b.objective_function(configuration.get_dictionary(),
+                    #                                    subsample=subsample, 
+                    #                                    n_estimators=n_estimators)
+
+                    # New API ---- Use this
+                    fidelity = {"n_estimators": n_estimator, "subsample": subsample}
                     result_dict = b.objective_function(configuration.get_dictionary(),
-                                                       n_estimators=n_estimator, subsample=subsample)
+                                                       fidelity=fidelity)
                     valid_loss = result_dict['function_value']
                     train_loss = result_dict['train_loss']
 

--- a/examples/w_optimizer/cartpole_bohb.py
+++ b/examples/w_optimizer/cartpole_bohb.py
@@ -34,7 +34,11 @@ class CustomWorker(Worker):
 
     def compute(self, config, budget, **kwargs):
         b = Benchmark(rng=self.seed)
-        result_dict = b.objective_function(config, budget=int(budget))
+        # Old API ---- NO LONGER SUPPORTED ---- This will simply ignore the fidelities
+        # result_dict = b.objective_function(config, budget=int(budget))
+        
+        # New API ---- Use this
+        result_dict = b.objective_function(config, fidelity={"budget": int(budget)})
         return {'loss': result_dict['function_value'],
                 'info': {'cost': result_dict['cost'],
                          'budget': result_dict['budget']}}
@@ -100,8 +104,13 @@ def run_experiment(out_path, on_travis):
 
     if not on_travis:
         benchmark = Benchmark(container_source='library://phmueller/automl')
+        # Old API ---- NO LONGER SUPPORTED ---- This will simply ignore the fidelities
+        # incumbent_result = benchmark.objective_function_test(configuration=inc_cfg,
+        #                                                      budget=settings['max_budget'])
+        
+        # New API ---- Use this
         incumbent_result = benchmark.objective_function_test(configuration=inc_cfg,
-                                                             budget=settings['max_budget'])
+                                                             fidelity={"budget": settings['max_budget']})
         print(incumbent_result)
 
 

--- a/examples/w_optimizer/cartpole_hyperband.py
+++ b/examples/w_optimizer/cartpole_hyperband.py
@@ -64,7 +64,11 @@ def run_experiment(out_path: str, on_travis: bool = False):
                       container_name='cartpole',
                       rng=seed)
 
-        result_dict = b.objective_function(cfg, budget=int(budget))
+        # Old API ---- NO LONGER SUPPORTED ---- This will simply ignore the fidelities
+        # result_dict = b.objective_function(cfg, budget=int(budget))
+
+        # New API ---- Use this
+        result_dict = b.objective_function(cfg, fidelity={"budget": int(budget)})
         return result_dict['function_value']
 
     smac = SMAC4HPO(scenario=scenario,

--- a/examples/w_optimizer/cartpole_succesive_halving.py
+++ b/examples/w_optimizer/cartpole_succesive_halving.py
@@ -61,7 +61,11 @@ def run_experiment(out_path: str, on_travis: bool = False):
                       container_name='cartpole',
                       rng=seed)
 
-        result_dict = b.objective_function(cfg, budget=int(budget))
+        # Old API ---- NO LONGER SUPPORTED ---- This will simply ignore the fidelities
+        # result_dict = b.objective_function(cfg, budget=int(budget))
+
+        # New API ---- Use this
+        result_dict = b.objective_function(cfg, fidelity={"budget": int(budget)})
         return result_dict['function_value']
 
     smac = SMAC4HPO(scenario=scenario,

--- a/hpolib/abstract_benchmark.py
+++ b/hpolib/abstract_benchmark.py
@@ -35,7 +35,8 @@ class AbstractBenchmark(object, metaclass=abc.ABCMeta):
         self.fidelity_space = self.get_fidelity_space()
 
     @abc.abstractmethod
-    def objective_function(self, configuration: Dict, rng: Union[np.random.RandomState, int, None] = None,
+    def objective_function(self, configuration: Dict, fidelity: Dict = None,
+                           rng: Union[np.random.RandomState, int, None] = None,
                            *args, **kwargs) -> dict:
         """
         Objective function.
@@ -50,6 +51,8 @@ class AbstractBenchmark(object, metaclass=abc.ABCMeta):
         Parameters
         ----------
         configuration : Dict
+        fidelity: Dict, None
+            Fidelity parameters, check get_fidelity_space(). Uses default (max) value if None.
         rng : np.random.RandomState, int, None
             It might be useful to pass a `rng` argument to the function call to
             bypass the default "seed" generator. Only using the default random
@@ -64,7 +67,8 @@ class AbstractBenchmark(object, metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def objective_function_test(self, configuration: Dict,  rng: Union[np.random.RandomState, int, None] = None,
+    def objective_function_test(self, configuration: Dict,  fidelity: Dict = None,
+                                rng: Union[np.random.RandomState, int, None] = None,
                                 *args, **kwargs) -> Dict:
         """
         If there is a different objective function for offline testing, e.g
@@ -74,6 +78,8 @@ class AbstractBenchmark(object, metaclass=abc.ABCMeta):
         Parameters
         ----------
         configuration : Dict
+        fidelity: Dict, None
+            Fidelity parameters, check get_fidelity_space(). Uses default (max) value if None.
         rng : np.random.RandomState, int, None
             see :py:func:`~HPOlib3.abstract_benchmark.objective_function`
 

--- a/hpolib/abstract_benchmark.py
+++ b/hpolib/abstract_benchmark.py
@@ -35,7 +35,6 @@ class AbstractBenchmark(object, metaclass=abc.ABCMeta):
         self.fidelity_space = self.get_fidelity_space()
 
     @property
-    @abc.abstractmethod
     def opt_fidelity(self) -> ConfigSpace.Configuration:
         return self.get_fidelity_space().get_default_configuration()
 

--- a/hpolib/benchmarks/ml/xgboost_benchmark.py
+++ b/hpolib/benchmarks/ml/xgboost_benchmark.py
@@ -222,6 +222,31 @@ class XGBoostBenchmark(AbstractBenchmark):
         return cs
 
     @staticmethod
+    def get_fidelity_space(seed: Union[int, None] = None) -> CS.ConfigurationSpace:
+        """
+        Creates a ConfigSpace.ConfigurationSpace containing all fidelity parameters for
+        the XGBoost Model
+
+        Parameters
+        ----------
+        seed : int, None
+            Fixing the seed for the ConfigSpace.ConfigurationSpace
+
+        Returns
+        -------
+        ConfigSpace.ConfigurationSpace
+        """
+        seed = seed if seed is not None else np.random.randint(1, 100000)
+        fidel_space = CS.ConfigurationSpace(seed=seed)
+
+        fidel_space.add_hyperparameters([
+            CS.UniformFloatHyperparameter("subsample", lower=0.1, upper=1.0, default=1.0, log=False),
+            CS.UniformIntegerHyperparameter("n_estimators", lower=2, upper=128, default=128, log=False)
+        ])
+
+        return fidel_space
+
+    @staticmethod
     def get_meta_information() -> Dict:
         """ Returns the meta information for the benchmark """
         return {'name': 'XGBoost',

--- a/hpolib/benchmarks/ml/xgboost_benchmark.py
+++ b/hpolib/benchmarks/ml/xgboost_benchmark.py
@@ -90,6 +90,7 @@ class XGBoostBenchmark(AbstractBenchmark):
 
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
+    @AbstractBenchmark._check_fidelity
     def objective_function(self, configuration: Union[Dict, CS.Configuration], n_estimators: int = 128,
                            subsample: float = 1,
                            shuffle: bool = False, rng: Union[np.random.RandomState, int, None] = None,
@@ -151,6 +152,7 @@ class XGBoostBenchmark(AbstractBenchmark):
 
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
+    @AbstractBenchmark._check_fidelity
     def objective_function_test(self, configuration: Union[Dict, CS.Configuration],
                                 subsample: float = 1, n_estimators: int = 128,
                                 rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:

--- a/hpolib/benchmarks/ml/xgboost_benchmark.py
+++ b/hpolib/benchmarks/ml/xgboost_benchmark.py
@@ -240,8 +240,8 @@ class XGBoostBenchmark(AbstractBenchmark):
         fidel_space = CS.ConfigurationSpace(seed=seed)
 
         fidel_space.add_hyperparameters([
-            CS.UniformFloatHyperparameter("subsample", lower=0.1, upper=1.0, default=1.0, log=False),
-            CS.UniformIntegerHyperparameter("n_estimators", lower=2, upper=128, default=128, log=False)
+            CS.UniformFloatHyperparameter("subsample", lower=0.1, upper=1.0, default_value=1.0, log=False),
+            CS.UniformIntegerHyperparameter("n_estimators", lower=2, upper=128, default_value=128, log=False)
         ])
 
         return fidel_space

--- a/hpolib/benchmarks/ml/xgboost_benchmark.py
+++ b/hpolib/benchmarks/ml/xgboost_benchmark.py
@@ -225,7 +225,7 @@ class XGBoostBenchmark(AbstractBenchmark):
     def get_fidelity_space(seed: Union[int, None] = None) -> CS.ConfigurationSpace:
         """
         Creates a ConfigSpace.ConfigurationSpace containing all fidelity parameters for
-        the XGBoost Model
+        the XGBoost Benchmark
 
         Parameters
         ----------

--- a/hpolib/benchmarks/ml/xgboost_benchmark.py
+++ b/hpolib/benchmarks/ml/xgboost_benchmark.py
@@ -91,8 +91,8 @@ class XGBoostBenchmark(AbstractBenchmark):
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._check_fidelity
-    def objective_function(self, configuration: Union[Dict, CS.Configuration], n_estimators: int = 128,
-                           subsample: float = 1,
+    def objective_function(self, configuration: Union[Dict, CS.Configuration],
+                           fidelity: Dict = None,
                            shuffle: bool = False, rng: Union[np.random.RandomState, int, None] = None,
                            **kwargs) -> Dict:
         """
@@ -103,10 +103,8 @@ class XGBoostBenchmark(AbstractBenchmark):
         ----------
         configuration : Dict, CS.Configuration
             Configuration for the XGBoost model
-        n_estimators : int
-            Number of trees to fit.
-        subsample : float
-            Subsample ratio of the training instance.
+        fidelity: Dict, None
+            Fidelity parameters for the XGBoost model, check get_fidelity_space(). Uses default (max) value if None.
         shuffle : bool
             If ``True``, shuffle the training idx. If no parameter ``rng`` is given, use the class random state.
             Defaults to ``False``.
@@ -127,6 +125,8 @@ class XGBoostBenchmark(AbstractBenchmark):
             subsample : fraction which was used to subsample the training data
 
         """
+        subsample = fidelity["subsample"]
+        n_estimators = fidelity["n_estimators"]
         assert 0 < subsample <= 1, ValueError(f'Parameter \'subsample\' must be in range (0, 1] but was {subsample}')
 
         self.rng = rng_helper.get_rng(rng=rng, self_rng=self.rng)
@@ -154,7 +154,7 @@ class XGBoostBenchmark(AbstractBenchmark):
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._check_fidelity
     def objective_function_test(self, configuration: Union[Dict, CS.Configuration],
-                                subsample: float = 1, n_estimators: int = 128,
+                                fidelity: Dict = None,
                                 rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
         """
         Trains a XGBoost model with a given configuration on both the train
@@ -164,10 +164,8 @@ class XGBoostBenchmark(AbstractBenchmark):
         ----------
         configuration : Dict, CS.Configuration
             Configuration for the XGBoost Model
-        n_estimators : int
-            Number of trees to fit.
-        subsample: float
-            Fraction which was used to subsample the training data
+        fidelity: Dict, None
+            Fidelity parameters, check get_fidelity_space(). Uses default (max) value if None.
         rng : np.random.RandomState, int, None,
             Random seed for benchmark. By default the class level random seed.
             To prevent overfitting on a single seed, it is possible to pass a
@@ -181,6 +179,8 @@ class XGBoostBenchmark(AbstractBenchmark):
             function_value : test loss
             cost : time to train and evaluate the model
         """
+        subsample = fidelity["subsample"]
+        n_estimators = fidelity["n_estimators"]
         self.rng = rng_helper.get_rng(rng=rng, self_rng=self.rng)
 
         start = time.time()

--- a/hpolib/benchmarks/nas/nasbench_101.py
+++ b/hpolib/benchmarks/nas/nasbench_101.py
@@ -169,6 +169,30 @@ class NASCifar10BaseBenchmark(AbstractBenchmark):
         cs.seed(seed)
         return cs
 
+    @staticmethod
+    def get_fidelity_space(seed: Union[int, None] = None) -> CS.ConfigurationSpace:
+        """
+        Creates a ConfigSpace.ConfigurationSpace containing all fidelity parameters for
+        the NAS Benchmark 101.
+
+        Parameters
+        ----------
+        seed : int, None
+            Fixing the seed for the ConfigSpace.ConfigurationSpace
+
+        Returns
+        -------
+        ConfigSpace.ConfigurationSpace
+        """
+        seed = seed if seed is not None else np.random.randint(1, 100000)
+        fidel_space = CS.ConfigurationSpace(seed=seed)
+
+        fidel_space.add_hyperparameters([
+            CS.CategoricalHyperparameter('budget', choices=[4, 12, 36, 108], default_value=108)
+        ])
+
+        return fidel_space
+
 
 class NASCifar10ABenchmark(NASCifar10BaseBenchmark):
     def __init__(self, data_path: Union[Path, str, None] = './fcnet_tabular_benchmarks/',

--- a/hpolib/benchmarks/nas/nasbench_101.py
+++ b/hpolib/benchmarks/nas/nasbench_101.py
@@ -75,6 +75,7 @@ class NASCifar10BaseBenchmark(AbstractBenchmark):
 
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
+    @AbstractBenchmark._check_fidelity
     def objective_function(self, configuration: Union[CS.Configuration, Dict],
                            budget: Union[int, None] = 108,
                            reset: Union[bool, None] = True,
@@ -119,6 +120,7 @@ class NASCifar10BaseBenchmark(AbstractBenchmark):
 
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
+    @AbstractBenchmark._check_fidelity
     def objective_function_test(self, configuration: Union[Dict, CS.Configuration],
                                 budget: Union[int, None] = 108,
                                 rng: Union[np.random.RandomState, int, None] = None,
@@ -188,7 +190,7 @@ class NASCifar10BaseBenchmark(AbstractBenchmark):
         fidel_space = CS.ConfigurationSpace(seed=seed)
 
         fidel_space.add_hyperparameters([
-            CS.CategoricalHyperparameter('budget', choices=[4, 12, 36, 108], default_value=108)
+            CS.OrdinalHyperparameter('budget', sequence=[4, 12, 36, 108], default_value=108)
         ])
 
         return fidel_space

--- a/hpolib/benchmarks/nas/nasbench_101.py
+++ b/hpolib/benchmarks/nas/nasbench_101.py
@@ -77,7 +77,7 @@ class NASCifar10BaseBenchmark(AbstractBenchmark):
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._check_fidelity
     def objective_function(self, configuration: Union[CS.Configuration, Dict],
-                           budget: Union[int, None] = 108,
+                           fidelity: Dict = None,
                            reset: Union[bool, None] = True,
                            rng: Union[np.random.RandomState, int, None] = None,
                            **kwargs) -> Dict:
@@ -87,8 +87,8 @@ class NASCifar10BaseBenchmark(AbstractBenchmark):
         Parameters
         ----------
         configuration : Dict, CS.Configuration
-        budget : int, None
-            Query the tabular benchmark at the `budget`-th epoch. Defaults to the maximum budget (108).
+        fidelity: Dict, None
+            Fidelity parameters, check get_fidelity_space(). Uses default (max) value if None.
         reset : bool, None
             Reset the internal memory of the benchmark. Should not have an effect. Default to True.
         rng : np.random.RandomState, int, None
@@ -105,6 +105,7 @@ class NASCifar10BaseBenchmark(AbstractBenchmark):
             function_value : validation error
             cost : runtime
         """
+        budget = fidelity["budget"]
         assert budget in [4, 12, 36, 108], f'This benchmark supports only budgets [4, 12, 36, 108], but was {budget}'
 
         if reset:
@@ -122,7 +123,7 @@ class NASCifar10BaseBenchmark(AbstractBenchmark):
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._check_fidelity
     def objective_function_test(self, configuration: Union[Dict, CS.Configuration],
-                                budget: Union[int, None] = 108,
+                                fidelity: Dict = None,
                                 rng: Union[np.random.RandomState, int, None] = None,
                                 **kwargs) -> Dict:
         """
@@ -131,7 +132,8 @@ class NASCifar10BaseBenchmark(AbstractBenchmark):
         Parameters
         ----------
         configuration : Dict, CS.Configuration
-        budget : int, None
+        fidelity: Dict, None
+            Fidelity parameters, check get_fidelity_space(). Uses default (max) value if None.
         rng : np.random.RandomState, int, None
             Random seed to use in the benchmark. To prevent overfitting on a single seed, it is possible to pass a
             parameter ``rng`` as 'int' or 'np.random.RandomState' to this function.
@@ -146,7 +148,7 @@ class NASCifar10BaseBenchmark(AbstractBenchmark):
         """
         self.rng = rng_helper.get_rng(rng, self_rng=self.rng)
 
-        test_error, runtime = self.benchmark.objective_function(config=configuration, budget=budget)
+        test_error, runtime = self.benchmark.objective_function(config=configuration, budget=fidelity["budget"])
         return {'function_value': float(test_error), 'cost': float(runtime)}
 
     @staticmethod

--- a/hpolib/benchmarks/nas/tabular_benchmarks.py
+++ b/hpolib/benchmarks/nas/tabular_benchmarks.py
@@ -167,6 +167,30 @@ class FCNetBaseBenchmark(AbstractBenchmark):
         cs.seed(seed)
         return cs
 
+    @staticmethod
+    def get_fidelity_space(seed: Union[int, None] = None) -> CS.ConfigurationSpace:
+        """
+        Creates a ConfigSpace.ConfigurationSpace containing all fidelity parameters for
+        the FCNetBaseBenchmark
+
+        Parameters
+        ----------
+        seed : int, None
+            Fixing the seed for the ConfigSpace.ConfigurationSpace
+
+        Returns
+        -------
+        ConfigSpace.ConfigurationSpace
+        """
+        seed = seed if seed is not None else np.random.randint(1, 100000)
+        fidel_space = CS.ConfigurationSpace(seed=seed)
+
+        fidel_space.add_hyperparameters([
+            CS.UniformIntegerHyperparameter('budget', lower=1, upper=100, default_value=100)
+        ])
+
+        return fidel_space
+
     def _reset_tracker(self):
         """ Helper function to reset the internal memory of the benchmark. """
         self.benchmark.X = []

--- a/hpolib/benchmarks/nas/tabular_benchmarks.py
+++ b/hpolib/benchmarks/nas/tabular_benchmarks.py
@@ -56,7 +56,7 @@ class FCNetBaseBenchmark(AbstractBenchmark):
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._check_fidelity
     def objective_function(self, configuration: Union[CS.Configuration, Dict],
-                           budget: Union[int, None] = 100,
+                           fidelity: Dict = None,
                            run_index: Union[int, Tuple, List, None] = (0, 1, 2, 3),
                            reset: Union[bool, None] = True,
                            rng: Union[np.random.RandomState, int, None] = None,
@@ -67,7 +67,8 @@ class FCNetBaseBenchmark(AbstractBenchmark):
         Parameters
         ----------
         configuration : Dict, CS.Configuration
-        budget : int, None
+        fidelity: Dict, None
+            Fidelity parameters, check get_fidelity_space(). Uses default (max) value if None.
         run_index : int, Tuple, None
             The nas benchmark has for each configuration-budget-pair results from 4 different runs.
             If multiple `run_id`s are given, the benchmark returns the mean over the given runs.

--- a/hpolib/benchmarks/nas/tabular_benchmarks.py
+++ b/hpolib/benchmarks/nas/tabular_benchmarks.py
@@ -54,6 +54,7 @@ class FCNetBaseBenchmark(AbstractBenchmark):
 
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
+    @AbstractBenchmark._check_fidelity
     def objective_function(self, configuration: Union[CS.Configuration, Dict],
                            budget: Union[int, None] = 100,
                            run_index: Union[int, Tuple, List, None] = (0, 1, 2, 3),
@@ -120,6 +121,7 @@ class FCNetBaseBenchmark(AbstractBenchmark):
 
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
+    @AbstractBenchmark._check_fidelity
     def objective_function_test(self, configuration: Union[Dict, CS.Configuration],
                                 rng: Union[np.random.RandomState, int, None] = None,
                                 **kwargs) -> Dict:

--- a/hpolib/benchmarks/rl/cartpole.py
+++ b/hpolib/benchmarks/rl/cartpole.py
@@ -67,6 +67,30 @@ class CartpoleBase(AbstractBenchmark):
         """ Returns the CS.ConfigurationSpace of the benchmark. """
         raise NotImplementedError()
 
+    @staticmethod
+    def get_fidelity_space(seed: Union[int, None] = None) -> CS.ConfigurationSpace:
+        """
+        Creates a ConfigSpace.ConfigurationSpace containing all fidelity parameters for
+        all Cartpole Benchmarks
+
+        Parameters
+        ----------
+        seed : int, None
+            Fixing the seed for the ConfigSpace.ConfigurationSpace
+
+        Returns
+        -------
+        ConfigSpace.ConfigurationSpace
+        """
+        seed = seed if seed is not None else np.random.randint(1, 100000)
+        fidel_space = CS.ConfigurationSpace(seed=seed)
+
+        fidel_space.add_hyperparameters([
+            CS.UniformIntegerHyperparameter('budget', lower=1, upper=9, default_value=9)
+        ])
+
+        return fidel_space
+
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
     def objective_function(self, configuration: Union[Dict, CS.Configuration], budget: Optional[int] = 9,

--- a/hpolib/benchmarks/rl/cartpole.py
+++ b/hpolib/benchmarks/rl/cartpole.py
@@ -94,7 +94,7 @@ class CartpoleBase(AbstractBenchmark):
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._check_fidelity
-    def objective_function(self, configuration: Union[Dict, CS.Configuration], budget: Optional[int] = 9,
+    def objective_function(self, configuration: Union[Dict, CS.Configuration], fidelity: Optional[Dict] = None,
                            rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
         """
         Trains a Tensorforce RL agent on the cartpole experiment. This benchmark was used in the experiments for the
@@ -106,8 +106,8 @@ class CartpoleBase(AbstractBenchmark):
         Parameters
         ----------
         configuration : Dict, CS.Configuration
-        budget : int, None
-            Num Agents. Defaults to 9
+        fidelity: Dict, None
+            Fidelity parameters, check get_fidelity_space(). Uses default (max) value if None.
         rng : np.random.RandomState, int, None
             Random seed to use in the benchmark. To prevent overfitting on a single seed, it is possible to pass a
             parameter ``rng`` as 'int' or 'np.random.RandomState' to this function.
@@ -124,6 +124,7 @@ class CartpoleBase(AbstractBenchmark):
             all_runs : the episode length of all runs of all agents
         """
         self.rng = rng_helper.get_rng(rng=rng, self_rng=self.rng)
+        budget = fidelity["budget"]
         tf.random.set_random_seed(self.rng.randint(1, 100000))
         np.random.seed(self.rng.randint(1, 100000))
 
@@ -182,7 +183,7 @@ class CartpoleBase(AbstractBenchmark):
 
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._check_fidelity
-    def objective_function_test(self, config: Union[Dict, CS.Configuration], budget: Optional[int] = 9,
+    def objective_function_test(self, config: Union[Dict, CS.Configuration], fidelity: Optional[Dict] = None,
                                 rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
         """
         Validate a configuration on the cartpole benchmark. Use the full budget.

--- a/hpolib/benchmarks/rl/cartpole.py
+++ b/hpolib/benchmarks/rl/cartpole.py
@@ -93,6 +93,7 @@ class CartpoleBase(AbstractBenchmark):
 
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
+    @AbstractBenchmark._check_fidelity
     def objective_function(self, configuration: Union[Dict, CS.Configuration], budget: Optional[int] = 9,
                            rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
         """
@@ -180,6 +181,7 @@ class CartpoleBase(AbstractBenchmark):
                 'all_runs': converged_episodes}
 
     @AbstractBenchmark._check_configuration
+    @AbstractBenchmark._check_fidelity
     def objective_function_test(self, config: Union[Dict, CS.Configuration], budget: Optional[int] = 9,
                                 rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
         """

--- a/hpolib/benchmarks/rl/learna_benchmark.py
+++ b/hpolib/benchmarks/rl/learna_benchmark.py
@@ -295,6 +295,7 @@ class Learna(BaseLearna):
 
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
+    @AbstractBenchmark._check_fidelity
     def objective_function(self, configuration: Union[Dict, CS.Configuration],
                            cutoff_agent_per_sequence: Union[int, float, None] = 600,
                            rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
@@ -345,6 +346,7 @@ class Learna(BaseLearna):
 
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
+    @AbstractBenchmark._check_fidelity
     def objective_function_test(self, configuration: Union[Dict, CS.Configuration],
                                 cutoff_agent_per_sequence: Union[int, float, None] = 600,
                                 rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:

--- a/hpolib/benchmarks/rl/learna_benchmark.py
+++ b/hpolib/benchmarks/rl/learna_benchmark.py
@@ -232,6 +232,30 @@ class BaseLearna(AbstractBenchmark):
         return config_space
 
     @staticmethod
+    def get_fidelity_space(seed: Union[int, None] = None) -> CS.ConfigurationSpace:
+        """
+        Creates a ConfigSpace.ConfigurationSpace containing all fidelity parameters for
+        a Learna Benchmark.
+
+        Parameters
+        ----------
+        seed : int, None
+            Fixing the seed for the ConfigSpace.ConfigurationSpace
+
+        Returns
+        -------
+        ConfigSpace.ConfigurationSpace
+        """
+        seed = seed if seed is not None else np.random.randint(1, 100000)
+        fidel_space = CS.ConfigurationSpace(seed=seed)
+
+        fidel_space.add_hyperparameters([
+            CS.UniformFloat('cutoff_agent_per_sequence', lower=1, upper=600, default_value=600)
+        ])
+
+        return fidel_space
+
+    @staticmethod
     def _fill_config(configuration: Dict) -> Dict:
         """ Helper function to fill the configuration space with the missing parameters """
 

--- a/hpolib/container/client_abstract_benchmark.py
+++ b/hpolib/container/client_abstract_benchmark.py
@@ -276,6 +276,27 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
         json_str = self.benchmark.get_configuration_space(seed_dict)
         return csjson.read(json_str)
 
+    def get_fidelity_space(self, seed: Union[int, None] = None) -> CS.ConfigurationSpace:
+        """
+        Get the fidelity space as a ConfigurationSpace object from the benchmark.
+
+        Parameters
+        ----------
+        seed : int, None
+            seed for the configuration space object. If None:  a random seed will be used.
+
+        Returns
+        -------
+            CS.ConfigurationSpace
+        """
+        seed_dict = {}
+        if seed is not None:
+            seed_dict['seed'] = seed
+        seed_dict = json.dumps(seed_dict, indent=None)
+        logger.debug(f'Client: seed_dict {seed_dict}')
+        json_str = self.benchmark.get_fidelity_space(seed_dict)
+        return csjson.read(json_str)
+
     def get_meta_information(self) -> Dict:
         """ Return the information about the benchmark. """
         json_str = self.benchmark.get_meta_information()

--- a/hpolib/container/server_abstract_benchmark.py
+++ b/hpolib/container/server_abstract_benchmark.py
@@ -85,6 +85,17 @@ class BenchmarkServer:
         logger.debug(f'Server: Configspace: {result}')
         return csjson.write(result, indent=None)
 
+    def get_fidelity_space(self, kwargs_str: str) -> str:
+        logger.debug(f'Server: get_fidelity_space: kwargs_str: {kwargs_str}')
+        seed = None
+        if kwargs_str != "{}":
+            kwargs = json.loads(kwargs_str)
+            seed = kwargs.get('seed', None)
+
+        result = self.benchmark.get_fidelity_space(seed=seed)
+        logger.debug(f'Server: Fidelity Space: {result}')
+        return csjson.write(result, indent=None)
+
     def objective_function_list(self, c_str: str, kwargs_str: str) -> str:
         configuration = json.loads(c_str)
         result = self.benchmark.objective_function(configuration, **json.loads(kwargs_str))


### PR DESCRIPTION
This is an initial implementation that essentially mimics the format used for defining the hyperparameter configuration spaces. It has been tested with the non-containerized XGBoost benchmark and tentative fidelity spaces have been added for non-containerized versions of all other benchmarks.