### PR TITLE
fix examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ config = b.get_configuration_space(seed=1).sample_configuration()
 result_dict = b.objective_function(configuration=config, fidelity={"n_estimators": 128, "subsample": 0.5}, rng=1)
 ```
 
-All benchmarks can als be queried with fewer or no fidelities:
+All benchmarks can also be queried with fewer or no fidelities:
 
 ```python
 from hpolib.container.benchmarks.ml.xgboost_benchmark import XGBoostBenchmark

--- a/examples/container/xgboost_with_container.py
+++ b/examples/container/xgboost_with_container.py
@@ -48,13 +48,7 @@ def run_experiment(on_travis: bool = False):
             print(configuration)
             for n_estimator in [8, 64]:
                 for subsample in [0.4, 1]:
-                    # Old API ---- NO LONGER SUPPORTED ---- This will simply ignore the fidelities
-                    # result_dict = b.objective_function(configuration.get_dictionary(),
-                    #                                    n_estimators=n_estimator,
-                    #                                    subsample=subsample)
-                    
-                    # New API ---- Use this
-                    fidelity = {"n_estimators": n_estimators, "subsample": subsample}
+                    fidelity = {"n_estimators": n_estimator, "subsample": subsample}
                     result_dict = b.objective_function(configuration.get_dictionary(),
                                                        fidelity=fidelity)
                     valid_loss = result_dict['function_value']

--- a/examples/container/xgboost_with_container.py
+++ b/examples/container/xgboost_with_container.py
@@ -52,7 +52,8 @@ def run_experiment(on_travis: bool = False):
                     result_dict = b.objective_function(configuration.get_dictionary(),
                                                        fidelity=fidelity)
                     valid_loss = result_dict['function_value']
-                    train_loss = result_dict['train_loss']
+                    train_loss = result_dict['info']['train_loss']
+                    assert result_dict['info']['fidelity'] == fidelity
 
                     result_dict = b.objective_function_test(configuration, n_estimators=n_estimator)
                     test_loss = result_dict['function_value']

--- a/examples/local/xgboost_local.py
+++ b/examples/local/xgboost_local.py
@@ -34,12 +34,6 @@ def run_experiment(on_travis: bool = False):
             print(configuration)
             for n_estimator in [8, 64]:
                 for subsample in [0.4, 1]:
-                    # Old API ---- NO LONGER SUPPORTED ---- This will simply ignore the fidelities
-                    # result_dict = b.objective_function(configuration.get_dictionary(),
-                    #                                    subsample=subsample, 
-                    #                                    n_estimators=n_estimators)
-
-                    # New API ---- Use this
                     fidelity = {"n_estimators": n_estimator, "subsample": subsample}
                     result_dict = b.objective_function(configuration.get_dictionary(),
                                                        fidelity=fidelity)

--- a/examples/local/xgboost_local.py
+++ b/examples/local/xgboost_local.py
@@ -41,7 +41,7 @@ def run_experiment(on_travis: bool = False):
                     train_loss = result_dict['info']['train_loss']
                     assert result_dict['info']['fidelity'] == fidelity
 
-                    result_dict = b.objective_function_test(configuration, n_estimators=n_estimator)
+                    result_dict = b.objective_function_test(configuration)
                     test_loss = result_dict['function_value']
 
                     print(f'[{i+1}|{num_configs}] No Estimator: {n_estimator:3d} - '

--- a/examples/local/xgboost_local.py
+++ b/examples/local/xgboost_local.py
@@ -38,7 +38,7 @@ def run_experiment(on_travis: bool = False):
                     result_dict = b.objective_function(configuration.get_dictionary(),
                                                        fidelity=fidelity)
                     valid_loss = result_dict['function_value']
-                    train_loss = result_dict['train_loss']
+                    train_loss = result_dict['info']['train_loss']
 
                     result_dict = b.objective_function_test(configuration, n_estimators=n_estimator)
                     test_loss = result_dict['function_value']

--- a/examples/local/xgboost_local.py
+++ b/examples/local/xgboost_local.py
@@ -39,6 +39,7 @@ def run_experiment(on_travis: bool = False):
                                                        fidelity=fidelity)
                     valid_loss = result_dict['function_value']
                     train_loss = result_dict['info']['train_loss']
+                    assert result_dict['info']['fidelity'] == fidelity
 
                     result_dict = b.objective_function_test(configuration, n_estimators=n_estimator)
                     test_loss = result_dict['function_value']

--- a/hpolib/abstract_benchmark.py
+++ b/hpolib/abstract_benchmark.py
@@ -139,6 +139,10 @@ class AbstractBenchmark(object, metaclass=abc.ABCMeta):
         regardless of input, as a dictionary in the 'fidelity' keyword argument.
         """
         def wrapper(self, configuration: Union[np.ndarray, ConfigSpace.Configuration, Dict], **kwargs):
+            # Sanity check that there are no fidelities in **kwargs
+            for f in self.get_fidelity_space().get_hyperparameters():
+                if f.name in kwargs:
+                    raise ValueError("Fidelity parameter %s should not be part of kwargs" % f.name)
 
             # Initialize with default values
             fidelity = self.get_fidelity_space().get_default_configuration().get_dictionary()

--- a/hpolib/abstract_benchmark.py
+++ b/hpolib/abstract_benchmark.py
@@ -147,7 +147,7 @@ class AbstractBenchmark(object, metaclass=abc.ABCMeta):
             if kwargs_fidelity:
                 # If kwargs contains the 'fidelity' arg, extract any fidelity parameters it contains and fill in
                 # default values for the rest.
-                fidelity = {k: kwargs_fidelity.pop(k, v) for k, v in fidelity.items()}
+                fidelity = {k: kwargs_fidelity.get(k, v) for k, v in fidelity.items()}
 
                 # Ensure that the extracted fidelity values play well with the defined fidelity space
                 try:

--- a/hpolib/benchmarks/nas/nasbench_101.py
+++ b/hpolib/benchmarks/nas/nasbench_101.py
@@ -105,18 +105,18 @@ class NASCifar10BaseBenchmark(AbstractBenchmark):
             function_value : validation error
             cost : runtime
         """
-        budget = fidelity["budget"]
-        assert budget in [4, 12, 36, 108], f'This benchmark supports only budgets [4, 12, 36, 108], but was {budget}'
-
         if reset:
             self.benchmark.reset_tracker()
 
         self.rng = rng_helper.get_rng(rng, self_rng=self.rng)
 
-        # Returns (valid_error_rate: 1, runtime: 0) if it is invalid. E.g. config not ok or budget not in 4 12 36 108
-        valid_error_rate, runtime = self.benchmark.objective_function(config=configuration, budget=budget)
+        # Returns (valid_error_rate: 1, runtime: 0) if it is invalid, e.g. config not valid or
+        # budget not in 4 12 36 108
+        valid_error_rate, runtime = self.benchmark.objective_function(config=configuration,
+                                                                      budget=fidelity["budget"])
         return {'function_value': float(valid_error_rate),
                 'cost': float(runtime),
+                'info': {'fidelity': fidelity}
                 }
 
     @AbstractBenchmark._configuration_as_dict
@@ -135,9 +135,9 @@ class NASCifar10BaseBenchmark(AbstractBenchmark):
         fidelity: Dict, None
             Fidelity parameters, check get_fidelity_space(). Uses default (max) value if None.
         rng : np.random.RandomState, int, None
-            Random seed to use in the benchmark. To prevent overfitting on a single seed, it is possible to pass a
-            parameter ``rng`` as 'int' or 'np.random.RandomState' to this function.
-            If this parameter is not given, the default random state is used.
+            Random seed to use in the benchmark. To prevent overfitting on a single seed, it is
+            possible to pass a parameter ``rng`` as 'int' or 'np.random.RandomState' to this
+            function. If this parameter is not given, the default random state is used.
         kwargs
 
         Returns
@@ -146,10 +146,8 @@ class NASCifar10BaseBenchmark(AbstractBenchmark):
             function_value : test error
             cost : runtime
         """
-        self.rng = rng_helper.get_rng(rng, self_rng=self.rng)
-
-        test_error, runtime = self.benchmark.objective_function(config=configuration, budget=fidelity["budget"])
-        return {'function_value': float(test_error), 'cost': float(runtime)}
+        return self.objective_function(configuration=configuration, fidelity=fidelity, rng=rng,
+                                       **kwargs)
 
     @staticmethod
     def get_configuration_space(seed: Union[int, None] = None) -> CS.ConfigurationSpace:

--- a/hpolib/benchmarks/rl/cartpole.py
+++ b/hpolib/benchmarks/rl/cartpole.py
@@ -177,13 +177,17 @@ class CartpoleBase(AbstractBenchmark):
 
         return {'function_value': np.mean(converged_episodes),
                 'cost': cost,
-                'max_episodes': self.max_episodes,
-                'budget': budget,
-                'all_runs': converged_episodes}
+                'info': {'max_episodes': self.max_episodes,
+                         'budget': budget,
+                         'all_runs': converged_episodes,
+                         'fidelity': fidelity
+                         }
+                }
 
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._check_fidelity
-    def objective_function_test(self, config: Union[Dict, CS.Configuration], fidelity: Optional[Dict] = None,
+    def objective_function_test(self, configuration: Union[Dict, CS.Configuration],
+                                fidelity: Optional[Dict] = None,
                                 rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
         """
         Validate a configuration on the cartpole benchmark. Use the full budget.
@@ -206,7 +210,8 @@ class CartpoleBase(AbstractBenchmark):
             budget : number of agents used
             all_runs : the episode length of all runs of all agents
         """
-        return self.objective_function(config, budget=budget, rng=rng, **kwargs)
+        return self.objective_function(configuration=configuration, fidelity=fidelity, rng=rng,
+                                       **kwargs)
 
     @staticmethod
     def get_meta_information() -> Dict:

--- a/hpolib/benchmarks/rl/cartpole.py
+++ b/hpolib/benchmarks/rl/cartpole.py
@@ -124,7 +124,6 @@ class CartpoleBase(AbstractBenchmark):
             all_runs : the episode length of all runs of all agents
         """
         self.rng = rng_helper.get_rng(rng=rng, self_rng=self.rng)
-        budget = fidelity["budget"]
         tf.random.set_random_seed(self.rng.randint(1, 100000))
         np.random.seed(self.rng.randint(1, 100000))
 
@@ -144,7 +143,7 @@ class CartpoleBase(AbstractBenchmark):
 
         converged_episodes = []
 
-        for i in range(budget):
+        for i in range(fidelity["budget"]):
             agent = PPOAgent(states=self.env.states,
                              actions=self.env.actions,
                              network=network_spec,
@@ -178,7 +177,6 @@ class CartpoleBase(AbstractBenchmark):
         return {'function_value': np.mean(converged_episodes),
                 'cost': cost,
                 'info': {'max_episodes': self.max_episodes,
-                         'budget': budget,
                          'all_runs': converged_episodes,
                          'fidelity': fidelity
                          }

--- a/hpolib/benchmarks/rl/learna_benchmark.py
+++ b/hpolib/benchmarks/rl/learna_benchmark.py
@@ -340,8 +340,10 @@ class Learna(BaseLearna):
 
         return {'function_value': validation_info["sum_of_min_distances"],
                 'cost': cost,
-                'num_solved': validation_info["num_solved"],
-                'sum_of_first_distances': validation_info["sum_of_first_distances"],
+                'info': {'num_solved': validation_info["num_solved"],
+                         'sum_of_first_distances': validation_info["sum_of_first_distances"],
+                         'fidelity': fidelity,
+                         }
                 }
 
     @AbstractBenchmark._configuration_as_dict
@@ -374,8 +376,8 @@ class Learna(BaseLearna):
             num_solved : int - number of soved sequences
             sum_of_first_distances : metric describing quality of result
         """
-        return self.objective_function(configuration, cutoff_agent_per_sequence=fidelity["cutoff_agent_per_sequence"],
-                                       rng=rng, **kwargs)
+        return self.objective_function(configuration=configuration, fidelity=fidelity, rng=rng,
+                                       **kwargs)
 
 
 class MetaLearna(BaseLearna):
@@ -442,7 +444,7 @@ class MetaLearna(BaseLearna):
         config, network_config, agent_config, env_config = self._setup(configuration)
         start_time = time()
         try:
-            train_info = self._train(budget=cutoff_agent_per_sequence,
+            train_info = self._train(budget=fidelity["cutoff_agent_per_sequence"],
                                      tmp_dir=tmp_dir,
                                      network_config=network_config,
                                      agent_config=agent_config,
@@ -462,8 +464,10 @@ class MetaLearna(BaseLearna):
 
         return {'function_value': validation_info["sum_of_min_distances"],
                 'cost': cost,
-                'train_info': train_info,
-                'validation_info': validation_info}
+                'info': {'train_info': train_info,
+                         'validation_info': validation_info,
+                         'fidelity': fidelity},
+                }
 
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
@@ -494,8 +498,8 @@ class MetaLearna(BaseLearna):
             num_solved : int - number of soved sequences
             sum_of_first_distances : metric describing quality of result
         """
-        return self.objective_function(configuration, cutoff_agent_per_sequence=fidelity["cutoff_agent_per_sequence"],
-                                       rng=rng, **kwargs)
+        return self.objective_function(configuration=configuration, fidelity=fidelity, rng=rng,
+                                       **kwargs)
 
     def _train(self, budget: Union[int, float], tmp_dir: Path, network_config: NetworkConfig,
                agent_config: AgentConfig, env_config: RnaDesignEnvironmentConfig) -> Dict:

--- a/tests/test_check_configuration.py
+++ b/tests/test_check_configuration.py
@@ -1,0 +1,68 @@
+from typing import Union, Tuple, Dict, List
+import unittest
+
+import numpy as np
+
+from ConfigSpace import ConfigurationSpace
+from ConfigSpace import UniformFloatHyperparameter, UniformIntegerHyperparameter, \
+    CategoricalHyperparameter
+
+from hpolib.abstract_benchmark import AbstractBenchmark
+
+
+class TestCheckUnittest(unittest.TestCase):
+
+    def setUp(self):
+        class Dummy():
+            configuration_space = ConfigurationSpace(seed=1)
+            flt = UniformFloatHyperparameter("flt", lower=0.0, upper=1.0)
+            cat = CategoricalHyperparameter("cat", choices=(1, "a"))
+            itg = UniformIntegerHyperparameter("itg", lower=0, upper=10)
+            configuration_space.add_hyperparameters([flt, cat, itg])
+
+            fidelity_space = ConfigurationSpace(seed=1)
+            f1 = UniformFloatHyperparameter("f_flt", lower=0.0, upper=1.0)
+            f2 = CategoricalHyperparameter("f_cat", choices=(1, "a"))
+            f3 = UniformIntegerHyperparameter("f_itg", lower=0, upper=10)
+            fidelity_space.add_hyperparameters([f1, f2, f3])
+
+            def get_fidelity_space(self):
+                return self.fidelity_space
+
+        self.foo = Dummy()
+
+    def test_config_decorator(self):
+        @AbstractBenchmark._configuration_as_dict
+        def tmp(_, configuration: Dict, **kwargs):
+            return configuration
+
+        ret = tmp(self=self.foo, configuration=self.foo.configuration_space.sample_configuration())
+        self.assertIsInstance(ret, Dict)
+
+        @AbstractBenchmark._check_configuration
+        def tmp(_, configuration: Dict, **kwargs):
+            return configuration
+        tmp(self=self.foo, configuration={"flt": 0.2, "cat": 1, "itg": 1})
+        tmp(self=self.foo, configuration=self.foo.configuration_space.sample_configuration())
+        self.assertRaises(Exception, tmp, {"self": self.foo, "configuration": {"flt": 0.2, "cat": 1}})
+
+    def test_fidel_decorator(self):
+        @AbstractBenchmark._check_fidelity
+        def tmp(_, configuration: Dict, fidelity: Dict, **kwargs):
+            return configuration, fidelity
+
+        sample_fidel = dict(self.foo.get_fidelity_space().get_default_configuration())
+        _, ret = tmp(self=self.foo,
+                     configuration=self.foo.configuration_space.sample_configuration(),
+                     fidelity=sample_fidel)
+        self.assertEqual(ret, sample_fidel)
+
+        less_fidel = {"f_cat": 1}
+        _, ret = tmp(self=self.foo,
+                     configuration=self.foo.configuration_space.sample_configuration(),
+                     fidelity=less_fidel)
+        self.assertEqual(ret, sample_fidel)
+
+        _, ret = tmp(self=self.foo,
+                     configuration=self.foo.configuration_space.sample_configuration())
+        self.assertEqual(ret, sample_fidel)

--- a/tests/test_check_configuration.py
+++ b/tests/test_check_configuration.py
@@ -49,20 +49,27 @@ class TestCheckUnittest(unittest.TestCase):
     def test_fidel_decorator(self):
         @AbstractBenchmark._check_fidelity
         def tmp(_, configuration: Dict, fidelity: Dict, **kwargs):
-            return configuration, fidelity
+            return configuration, fidelity, kwargs
 
         sample_fidel = dict(self.foo.get_fidelity_space().get_default_configuration())
-        _, ret = tmp(self=self.foo,
-                     configuration=self.foo.configuration_space.sample_configuration(),
-                     fidelity=sample_fidel)
+
+        _, ret, _ = tmp(self=self.foo,
+                        configuration=self.foo.configuration_space.sample_configuration(),
+                        fidelity=sample_fidel)
         self.assertEqual(ret, sample_fidel)
 
         less_fidel = {"f_cat": 1}
-        _, ret = tmp(self=self.foo,
-                     configuration=self.foo.configuration_space.sample_configuration(),
-                     fidelity=less_fidel)
+        _, ret, _ = tmp(self=self.foo,
+                        configuration=self.foo.configuration_space.sample_configuration(),
+                        fidelity=less_fidel)
         self.assertEqual(ret, sample_fidel)
 
-        _, ret = tmp(self=self.foo,
-                     configuration=self.foo.configuration_space.sample_configuration())
+        _, ret, _ = tmp(self=self.foo,
+                        configuration=self.foo.configuration_space.sample_configuration())
         self.assertEqual(ret, sample_fidel)
+
+        try:
+            tmp(self=self.foo, configuration=self.foo.configuration_space.sample_configuration(),
+                f_cat=1)
+        except ValueError as e:
+            self.assertEqual(e.__str__(), "Fidelity parameter f_cat should not be part of kwargs")

--- a/tests/test_tabular_benchmarks.py
+++ b/tests/test_tabular_benchmarks.py
@@ -3,21 +3,20 @@ import pytest
 import logging
 logging.basicConfig(level=logging.DEBUG)
 
-from hpolib.container.benchmarks.nas.tabular_benchmarks import SliceLocalizationBenchmark, NavalPropulsionBenchmark, \
-    ParkinsonsTelemonitoringBenchmark, ProteinStructureBenchmark
+from hpolib.container.benchmarks.nas.tabular_benchmarks import SliceLocalizationBenchmark, \
+    NavalPropulsionBenchmark, ParkinsonsTelemonitoringBenchmark, ProteinStructureBenchmark
 
 
 def setup():
-    container_source = 'library://phmueller/automl/'
-    benchmark = SliceLocalizationBenchmark(container_source=container_source)
+    benchmark = SliceLocalizationBenchmark()
     default_config = benchmark.get_configuration_space(seed=1).get_default_configuration()
 
-    return container_source, default_config
+    return default_config
 
 
 def test_tabular_benchmark_wrong_input():
     container_source, default_config = setup()
-    benchmark = SliceLocalizationBenchmark(container_source=container_source, rng=1)
+    benchmark = SliceLocalizationBenchmark(rng=1)
 
     with pytest.raises(AssertionError):
         benchmark.objective_function(configuration=default_config, budget=0)
@@ -46,7 +45,7 @@ def test_tabular_benchmark_wrong_input():
 def test_slice_benchmark():
     container_source, default_config = setup()
 
-    benchmark = SliceLocalizationBenchmark(container_source=container_source, rng=1)
+    benchmark = SliceLocalizationBenchmark(rng=1)
     result = benchmark.objective_function(configuration=default_config, budget=1, run_index=[0, 1, 2, 3])
 
     mean = 0.01828
@@ -68,7 +67,7 @@ def test_slice_benchmark():
 def test_naval_benchmark():
     container_source, default_config = setup()
 
-    benchmark = NavalPropulsionBenchmark(container_source=container_source)
+    benchmark = NavalPropulsionBenchmark(rng=1)
     result = benchmark.objective_function(configuration=default_config, budget=1, run_index=[0, 1, 2, 3])
 
     mean = 0.8928
@@ -90,7 +89,7 @@ def test_naval_benchmark():
 def test_protein_benchmark():
     container_source, default_config = setup()
 
-    benchmark = ProteinStructureBenchmark(container_source=container_source, rng=1)
+    benchmark = ProteinStructureBenchmark(rng=1)
     result = benchmark.objective_function(configuration=default_config, budget=1, run_index=[0, 1, 2, 3])
 
     mean = 0.4474
@@ -112,7 +111,7 @@ def test_protein_benchmark():
 def test_parkinson_benchmark():
     container_source, default_config = setup()
 
-    benchmark = ParkinsonsTelemonitoringBenchmark(container_source=container_source, rng=1)
+    benchmark = ParkinsonsTelemonitoringBenchmark(rng=1)
     result = benchmark.objective_function(configuration=default_config, budget=1, run_index=[0, 1, 2, 3])
 
     mean = 0.7425

--- a/tests/test_whitebox.py
+++ b/tests/test_whitebox.py
@@ -17,7 +17,6 @@ def test_whitebox_without_container_xgb():
     b = Benchmark(task_id=167199, rng=0)
     cs = b.get_configuration_space(seed=0)
 
-    start = time()
     configuration = cs.get_default_configuration()
     assert configuration['colsample_bylevel'] == 1.0
     assert len(configuration.keys()) == 6
@@ -39,8 +38,7 @@ def test_whitebox_without_container_xgb():
 @pytest.mark.skipif(skip_container_test, reason="Requires singularity and flask")
 def test_whitebox_with_container():
     from hpolib.container.benchmarks.ml.xgboost_benchmark import XGBoostBenchmark as Benchmark
-    b = Benchmark(container_source='library://phmueller/automl/',
-                  container_name='xgboost_benchmark',
+    b = Benchmark(container_name='xgboost_benchmark',
                   task_id=167199,
                   rng=0)
 
@@ -62,17 +60,16 @@ def test_whitebox_with_container():
     assert np.isclose(valid_loss, 0.3873, atol=0.001)
     assert np.isclose(test_loss, 0.38181, atol=0.001)
 
+
 def test_cartpole():
     from hpolib.container.benchmarks.rl.cartpole import CartpoleReduced as Benchmark
-    b = Benchmark(container_source='library://phmueller/automl',
-                  container_name='cartpole',
+    b = Benchmark(container_name='cartpole',
                   rng=1)
     cs = b.get_configuration_space(seed=1)
     print(cs.get_default_configuration())
 
     from hpolib.container.benchmarks.rl.cartpole import CartpoleFull as Benchmark
-    b = Benchmark(container_source='library://phmueller/automl',
-                  container_name='cartpole',
+    b = Benchmark(container_name='cartpole',
                   rng=1)
     cs = b.get_configuration_space(seed=1)
     print(cs.get_default_configuration())


### PR DESCRIPTION
Do a pass over all interfaces, fixed the following:

  * objective_test will always accept fidelities (and might or might not use them)
  * objective_function returns all extra information in "info"
  * fixed config->configuration
  * fixed typo in examples
  * Updated examples in README
  * fidelity decorator no longer empties fidelity dict
  * Raise error if fidelity is part of kwargs
  * added unittests for decorators

*Note:* Container are supposed to crash