### PR TITLE
Server support Fidelities + Unify Interface + Bug fixing

### DIFF
--- a/examples/container/xgboost_with_container.py
+++ b/examples/container/xgboost_with_container.py
@@ -38,7 +38,8 @@ def run_experiment(on_travis: bool = False):
 
         b = Benchmark(task_id=task_id,
                       container_name='xgboost_benchmark',
-                      container_source='library://phmueller/automl')
+                      # container_source='library://phmueller/automl')
+                      container_source='/home/philipp/Dokumente/Code/TabularBenchmarks/Container')
 
         cs = b.get_configuration_space()
         start = time()

--- a/examples/container/xgboost_with_container.py
+++ b/examples/container/xgboost_with_container.py
@@ -12,7 +12,7 @@ To use the container-example, you have to have singulartiy (>3.5) installed. Fol
 https://sylabs.io/guides/3.1/user-guide/quick_start.html#quick-installation-steps
 
 Furthermore, make sure to install the right dependencies for the hpolib via:
-``pip3 install .[xgboost_example,singularity]``.
+``pip3 install .[singularity]``.
 """
 
 import argparse
@@ -48,7 +48,7 @@ def run_experiment(on_travis: bool = False):
             print(configuration)
             for n_estimator in [8, 64]:
                 for subsample in [0.4, 1]:
-                    fidelity = {"n_estimators": n_estimator, "subsample": subsample}
+                    fidelity = {'n_estimators': n_estimator, 'subsample': subsample}
                     result_dict = b.objective_function(configuration.get_dictionary(),
                                                        fidelity=fidelity)
                     valid_loss = result_dict['function_value']
@@ -65,12 +65,12 @@ def run_experiment(on_travis: bool = False):
         print(f'Done, took totally {time()-start:.2f}')
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     parser = argparse.ArgumentParser(prog='HPOlib CC Datasets', description='HPOlib3 on the CC18 data sets.',
                                      usage='%(prog)s --array_id <task_id>')
 
     parser.add_argument('--on_travis', action='store_true',
-                        help='Flag to speed up the run on the continuous integration tool \"travis\". This flag can be'
+                        help='Flag to speed up the run on the continuous integration tool \'travis\'. This flag can be'
                              'ignored by the user')
 
     args = parser.parse_args()

--- a/examples/container/xgboost_with_container.py
+++ b/examples/container/xgboost_with_container.py
@@ -56,7 +56,7 @@ def run_experiment(on_travis: bool = False):
                     train_loss = result_dict['info']['train_loss']
                     assert result_dict['info']['fidelity'] == fidelity
 
-                    result_dict = b.objective_function_test(configuration, n_estimators=n_estimator)
+                    result_dict = b.objective_function_test(configuration, fidelity={'n_estimators': n_estimator})
                     test_loss = result_dict['function_value']
 
                     print(f'[{i+1}|{num_configs}] No Estimator: {n_estimator:3d} - '

--- a/examples/container/xgboost_with_container.py
+++ b/examples/container/xgboost_with_container.py
@@ -38,8 +38,7 @@ def run_experiment(on_travis: bool = False):
 
         b = Benchmark(task_id=task_id,
                       container_name='xgboost_benchmark',
-                      # container_source='library://phmueller/automl')
-                      container_source='/home/philipp/Dokumente/Code/TabularBenchmarks/Container')
+                      container_source='library://phmueller/automl')
 
         cs = b.get_configuration_space()
         start = time()

--- a/examples/local/xgboost_local.py
+++ b/examples/local/xgboost_local.py
@@ -34,7 +34,7 @@ def run_experiment(on_travis: bool = False):
             print(configuration)
             for n_estimator in [8, 64]:
                 for subsample in [0.4, 1]:
-                    fidelity = {"n_estimators": n_estimator, "subsample": subsample}
+                    fidelity = {'n_estimators': n_estimator, 'subsample': subsample}
                     result_dict = b.objective_function(configuration.get_dictionary(),
                                                        fidelity=fidelity)
                     valid_loss = result_dict['function_value']
@@ -50,12 +50,12 @@ def run_experiment(on_travis: bool = False):
         print(f'Done, took totally {time()-start:.2f}')
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     parser = argparse.ArgumentParser(prog='HPOlib CC Datasets', description='HPOlib3 on the CC18 data sets.',
                                      usage='%(prog)s --array_id <task_id>')
 
     parser.add_argument('--on_travis', action='store_true',
-                        help='Flag to speed up the run on the continuous integration tool \"travis\". This flag can be'
+                        help='Flag to speed up the run on the continuous integration tool \'travis\'. This flag can be'
                              'ignored by the user')
 
     args = parser.parse_args()

--- a/extra_requirements/xgboost.json
+++ b/extra_requirements/xgboost.json
@@ -1,3 +1,3 @@
 {
-  "xgboost": ["xgboost==0.90","pandas>=0.22.2,<24.2","openml==0.10.2"]
+  "xgboost": ["xgboost==0.90","pandas>=0.22.2,<0.24.2","openml==0.10.2"]
 }

--- a/hpolib/abstract_benchmark.py
+++ b/hpolib/abstract_benchmark.py
@@ -35,7 +35,7 @@ class AbstractBenchmark(object, metaclass=abc.ABCMeta):
         self.fidelity_space = self.get_fidelity_space()
 
     @abc.abstractmethod
-    def objective_function(self, configuration: Dict, fidelity: Dict = None,
+    def objective_function(self, configuration: Dict, fidelity: Union[Dict, None] = None,
                            rng: Union[np.random.RandomState, int, None] = None,
                            *args, **kwargs) -> dict:
         """
@@ -62,12 +62,12 @@ class AbstractBenchmark(object, metaclass=abc.ABCMeta):
         Returns
         -------
         Dict
-            Must contain at least the key `function_value`.
+            Must contain at least the key `function_value` and `cost`.
         """
         pass
 
     @abc.abstractmethod
-    def objective_function_test(self, configuration: Dict,  fidelity: Dict = None,
+    def objective_function_test(self, configuration: Dict, fidelity: Union[Dict, None] = None,
                                 rng: Union[np.random.RandomState, int, None] = None,
                                 *args, **kwargs) -> Dict:
         """
@@ -86,7 +86,7 @@ class AbstractBenchmark(object, metaclass=abc.ABCMeta):
         Returns
         -------
         Dict
-            Must contain at least the key `function_value`.
+            Must contain at least the key `function_value` and `cost`.
         """
         pass
 
@@ -101,22 +101,22 @@ class AbstractBenchmark(object, metaclass=abc.ABCMeta):
         Can be combined with the _configuration_as_array decorator.
         """
         def wrapper(self, configuration: Union[np.ndarray, ConfigSpace.Configuration, Dict], **kwargs):
-            if isinstance(configuration, np.ndarray):
-                try:
+
+            try:
+                if isinstance(configuration, np.ndarray):
                     config_dict = {k: configuration[i] for (i, k) in enumerate(self.configuration_space)}
                     config = ConfigSpace.Configuration(self.configuration_space, config_dict)
-                except Exception as e:
-                    raise Exception('Error during the conversion of the provided configuration '
-                                    'into a ConfigSpace.Configuration object') from e
-            elif isinstance(configuration, dict):
-                try:
+                elif isinstance(configuration, dict):
                     config = ConfigSpace.Configuration(self.configuration_space, configuration)
-                except Exception as e:
-                    raise Exception('Error during the conversion of the provided configuration '
-                                    'into a ConfigSpace.Configuration object') from e
-            elif isinstance(configuration, ConfigSpace.Configuration):
-                config = configuration
-            else:
+                elif isinstance(configuration, ConfigSpace.Configuration):
+                    config = configuration
+                else:
+                    config = None
+            except Exception as e:
+                raise Exception('Error during the conversion of the provided configuration '
+                                'into a ConfigSpace.Configuration object') from e
+
+            if config is None:
                 raise TypeError(f'Configuration has to be from type np.ndarray, dict, or ConfigSpace.Configuration but '
                                 f'was {type(configuration)}')
 
@@ -138,28 +138,41 @@ class AbstractBenchmark(object, metaclass=abc.ABCMeta):
         Order independent from the _check_configuration decorator, but it does forward all fidelity parameters,
         regardless of input, as a dictionary in the 'fidelity' keyword argument.
         """
-        def wrapper(self, configuration: Union[np.ndarray, ConfigSpace.Configuration, Dict], **kwargs):
+        def wrapper(self, configuration: Union[np.ndarray, ConfigSpace.Configuration, Dict],
+                    fidelity: Union[Dict, ConfigSpace.Configuration, None] = None, **kwargs):
+
             # Sanity check that there are no fidelities in **kwargs
-            for f in self.get_fidelity_space().get_hyperparameters():
+            for f in self.fidelity_space.get_hyperparameters():
                 if f.name in kwargs:
                     raise ValueError("Fidelity parameter %s should not be part of kwargs" % f.name)
 
-            # Initialize with default values
-            fidelity = self.get_fidelity_space().get_default_configuration().get_dictionary()
+            # If kwargs contains the 'fidelity' arg, extract any fidelity parameters it contains and fill in
+            # default values for the rest.
+            default_fidelities = self.fidelity_space.get_default_configuration()
+            try:
+                if fidelity is None:
+                    fidelity = default_fidelities
+                if isinstance(fidelity, dict):
+                    default_fidelities_cfg = default_fidelities.get_dictionary()
+                    fidelity = {k: fidelity.get(k, v) for k, v in default_fidelities_cfg.items()}
+                    fidelity = ConfigSpace.Configuration(self.configuration_space, fidelity)
+                elif isinstance(fidelity, ConfigSpace.Configuration):
+                    fidelity = fidelity
+                else:
+                    fidelity = None
+            except Exception as e:
+                raise Exception('Error during the conversion of the provided fidelities '
+                                'into a FidelitySpace (ConfigSpace.Configuration) object') from e
 
-            kwargs_fidelity = kwargs.pop("fidelity", None)
-            if kwargs_fidelity:
-                # If kwargs contains the 'fidelity' arg, extract any fidelity parameters it contains and fill in
-                # default values for the rest.
-                fidelity = {k: kwargs_fidelity.get(k, v) for k, v in fidelity.items()}
+            if fidelity is None:
+                raise TypeError(f'Configuration has to be from type np.ndarray, dict, or ConfigSpace.Configuration but '
+                                f'was {type(configuration)}')
 
-                # Ensure that the extracted fidelity values play well with the defined fidelity space
-                try:
-                    fidel_config = ConfigSpace.Configuration(self.fidelity_space, fidelity)
-                except Exception as e:
-                    raise Exception('Error during conversion of the provided fidelity parameters to the benchmark\'s '
-                                    'space of known fidelity parameters.') from e
-                self.fidelity_space.check_configuration(fidel_config)
+            # Ensure that the extracted fidelity values play well with the defined fidelity space
+            self.fidelity_space.check_configuration(fidelity)
+
+            # All benchmarks should work on dictionaries. Cast the fidelity space object to a dictionary.
+            fidelity = fidelity.get_dictionary()
 
             return foo(self, configuration, fidelity=fidelity, **kwargs)
         return wrapper

--- a/hpolib/abstract_benchmark.py
+++ b/hpolib/abstract_benchmark.py
@@ -11,6 +11,7 @@ from hpolib.util import rng_helper
 
 logger = logging.getLogger('AbstractBenchmark')
 
+
 class AbstractBenchmark(object, metaclass=abc.ABCMeta):
 
     def __init__(self, rng: Union[int, np.random.RandomState, None] = None):
@@ -147,7 +148,8 @@ class AbstractBenchmark(object, metaclass=abc.ABCMeta):
             # Sanity check that there are no fidelities in **kwargs
             for f in self.fidelity_space.get_hyperparameters():
                 if f.name in kwargs:
-                    raise ValueError(f'Fidelity parameter {f.name} should not be part of kwargs')
+                    raise ValueError(f'Fidelity parameter {f.name} should not be part of kwargs\n'
+                                     f'Fidelity: {fidelity}\n Kwargs: {kwargs}')
 
             # If kwargs contains the 'fidelity' arg, extract any fidelity parameters it contains and fill in
             # default values for the rest.

--- a/hpolib/abstract_benchmark.py
+++ b/hpolib/abstract_benchmark.py
@@ -3,11 +3,13 @@
 import abc
 from typing import Union, Dict
 
+import logging
 import ConfigSpace
 import numpy as np
 
 from hpolib.util import rng_helper
 
+logger = logging.getLogger('AbstractBenchmark')
 
 class AbstractBenchmark(object, metaclass=abc.ABCMeta):
 
@@ -113,8 +115,9 @@ class AbstractBenchmark(object, metaclass=abc.ABCMeta):
                 else:
                     config = None
             except Exception as e:
-                raise Exception('Error during the conversion of the provided configuration '
-                                'into a ConfigSpace.Configuration object') from e
+                logger.error('Error during the conversion of the provided configuration '
+                             'into a ConfigSpace.Configuration object')
+                raise e
 
             if config is None:
                 raise TypeError(f'Configuration has to be from type np.ndarray, dict, or ConfigSpace.Configuration but '
@@ -144,7 +147,7 @@ class AbstractBenchmark(object, metaclass=abc.ABCMeta):
             # Sanity check that there are no fidelities in **kwargs
             for f in self.fidelity_space.get_hyperparameters():
                 if f.name in kwargs:
-                    raise ValueError("Fidelity parameter %s should not be part of kwargs" % f.name)
+                    raise ValueError(f'Fidelity parameter {f.name} should not be part of kwargs')
 
             # If kwargs contains the 'fidelity' arg, extract any fidelity parameters it contains and fill in
             # default values for the rest.
@@ -155,14 +158,15 @@ class AbstractBenchmark(object, metaclass=abc.ABCMeta):
                 if isinstance(fidelity, dict):
                     default_fidelities_cfg = default_fidelities.get_dictionary()
                     fidelity = {k: fidelity.get(k, v) for k, v in default_fidelities_cfg.items()}
-                    fidelity = ConfigSpace.Configuration(self.configuration_space, fidelity)
+                    fidelity = ConfigSpace.Configuration(self.fidelity_space, fidelity)
                 elif isinstance(fidelity, ConfigSpace.Configuration):
                     fidelity = fidelity
                 else:
                     fidelity = None
             except Exception as e:
-                raise Exception('Error during the conversion of the provided fidelities '
-                                'into a FidelitySpace (ConfigSpace.Configuration) object') from e
+                logger.error('Error during the conversion of the provided fidelities '
+                             'into a FidelitySpace (ConfigSpace.Configuration) object')
+                raise e
 
             if fidelity is None:
                 raise TypeError(f'Configuration has to be from type np.ndarray, dict, or ConfigSpace.Configuration but '

--- a/hpolib/benchmarks/nas/nasbench_101.py
+++ b/hpolib/benchmarks/nas/nasbench_101.py
@@ -77,8 +77,7 @@ class NASCifar10BaseBenchmark(AbstractBenchmark):
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._check_fidelity
     def objective_function(self, configuration: Union[CS.Configuration, Dict],
-                           fidelity: Dict = None,
-                           reset: Union[bool, None] = True,
+                           fidelity: Union[Dict, None] = None,
                            rng: Union[np.random.RandomState, int, None] = None,
                            **kwargs) -> Dict:
         """
@@ -89,8 +88,6 @@ class NASCifar10BaseBenchmark(AbstractBenchmark):
         configuration : Dict, CS.Configuration
         fidelity: Dict, None
             Fidelity parameters, check get_fidelity_space(). Uses default (max) value if None.
-        reset : bool, None
-            Reset the internal memory of the benchmark. Should not have an effect. Default to True.
         rng : np.random.RandomState, int, None
             Random seed to use in the benchmark.
 
@@ -104,9 +101,10 @@ class NASCifar10BaseBenchmark(AbstractBenchmark):
         Dict -
             function_value : validation error
             cost : runtime
+            info : Dict
+                fidelity : used fidelities in this evaluation
         """
-        if reset:
-            self.benchmark.reset_tracker()
+        self.benchmark.reset_tracker()
 
         self.rng = rng_helper.get_rng(rng, self_rng=self.rng)
 
@@ -123,7 +121,7 @@ class NASCifar10BaseBenchmark(AbstractBenchmark):
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._check_fidelity
     def objective_function_test(self, configuration: Union[Dict, CS.Configuration],
-                                fidelity: Dict = None,
+                                fidelity: Union[Dict, None] = None,
                                 rng: Union[np.random.RandomState, int, None] = None,
                                 **kwargs) -> Dict:
         """
@@ -145,6 +143,8 @@ class NASCifar10BaseBenchmark(AbstractBenchmark):
         Dict -
             function_value : test error
             cost : runtime
+            info : Dict
+                fidelity : used fidelities in this evaluation
         """
         return self.objective_function(configuration=configuration, fidelity=fidelity, rng=rng,
                                        **kwargs)

--- a/hpolib/benchmarks/nas/tabular_benchmarks.py
+++ b/hpolib/benchmarks/nas/tabular_benchmarks.py
@@ -31,7 +31,7 @@ python setup.py install
 """
 
 from pathlib import Path
-from typing import Union, Dict, Tuple, List
+from typing import Union, Dict, Tuple
 
 import ConfigSpace as CS
 import numpy as np
@@ -56,9 +56,8 @@ class FCNetBaseBenchmark(AbstractBenchmark):
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._check_fidelity
     def objective_function(self, configuration: Union[CS.Configuration, Dict],
-                           fidelity: Dict = None,
-                           run_index: Union[int, Tuple, List] = (0, 1, 2, 3),
-                           reset: Union[bool, None] = True,
+                           fidelity: Union[Dict, None] = None,
+                           run_index: Union[int, Tuple, None] = (0, 1, 2, 3),
                            rng: Union[np.random.RandomState, int, None] = None,
                            **kwargs) -> Dict:
         """
@@ -74,8 +73,6 @@ class FCNetBaseBenchmark(AbstractBenchmark):
             If multiple `run_id`s are given, the benchmark returns the mean over the given runs.
             By default all runs are used. A specific run can be chosen by setting the `run_id` to a
             value from [0, 3].
-        reset : bool, None
-            Reset the internal memory of the benchmark. Should not have an effect. Defaults to True.
         rng : np.random.RandomState, int, None
             Random seed to use in the benchmark. To prevent overfitting on a single seed, it is
             possible to pass a parameter ``rng`` as 'int' or 'np.random.RandomState' to this
@@ -88,6 +85,10 @@ class FCNetBaseBenchmark(AbstractBenchmark):
             function_value : validation loss
             cost : time to train and evaluate the model
             info : Dict with valid_rmse_per_run, runtime_per_run
+            info : Dict
+                valid_rmse_per_run
+                runtime_per_run
+                fidelity : used fidelities in this evaluation
         """
         self.rng = rng_helper.get_rng(rng)
 
@@ -99,11 +100,9 @@ class FCNetBaseBenchmark(AbstractBenchmark):
             assert min(run_index) >= 0 and max(run_index) <= 3, \
                 f'all run_index values must be in [0, 3], but were {run_index}'
         else:
-            raise ValueError(f'run index must be one of List, '
-                             f'Tuple or Int, but was {type(run_index)}')
+            raise ValueError(f'run index must be one of Tuple or Int, but was {type(run_index)}')
 
-        if reset:
-            self._reset_tracker()
+        self._reset_tracker()
 
         valid_rmse_list, runtime_list = [], []
         for run_id in run_index:
@@ -128,7 +127,7 @@ class FCNetBaseBenchmark(AbstractBenchmark):
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._check_fidelity
     def objective_function_test(self, configuration: Union[Dict, CS.Configuration],
-                                fidelity: Dict = None,
+                                fidelity: Union[Dict, None] = None,
                                 rng: Union[np.random.RandomState, int, None] = None,
                                 **kwargs) -> Dict:
         """
@@ -147,8 +146,12 @@ class FCNetBaseBenchmark(AbstractBenchmark):
         Returns
         -------
         Dict -
-            function_value : test loss
+            function_value : validation loss
             cost : time to train and evaluate the model
+            info : Dict
+                valid_rmse_per_run
+                runtime_per_run
+                fidelity : used fidelities in this evaluation
         """
         return self.objective_function(configuration=configuration, fidelity=fidelity, rng=rng,
                                        **kwargs)

--- a/hpolib/benchmarks/rl/cartpole.py
+++ b/hpolib/benchmarks/rl/cartpole.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from typing import Union, Optional, Dict
+from typing import Union, Dict
 
 import ConfigSpace as CS
 import numpy as np
@@ -18,8 +18,8 @@ logger = logging.getLogger('CartpoleBenchmark')
 
 
 class CartpoleBase(AbstractBenchmark):
-    def __init__(self, rng: Union[int, np.random.RandomState, None] = None, defaults: Optional[Dict] = None,
-                 max_episodes: Optional[int] = 3000):
+    def __init__(self, rng: Union[int, np.random.RandomState, None] = None, defaults: Union[Dict, None] = None,
+                 max_episodes: Union[int, None] = 3000):
         """
         Parameters
         ----------
@@ -94,7 +94,7 @@ class CartpoleBase(AbstractBenchmark):
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._check_fidelity
-    def objective_function(self, configuration: Union[Dict, CS.Configuration], fidelity: Optional[Dict] = None,
+    def objective_function(self, configuration: Union[Dict, CS.Configuration], fidelity: Union[Dict, None] = None,
                            rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
         """
         Trains a Tensorforce RL agent on the cartpole experiment. This benchmark was used in the experiments for the
@@ -119,9 +119,11 @@ class CartpoleBase(AbstractBenchmark):
         Dict -
             function_value : average episode length
             cost : time to run all agents
-            max_episodes : the maximum length of an episode
-            budget : number of agents used
-            all_runs : the episode length of all runs of all agents
+            info : Dict
+                max_episodes : the maximum length of an episode
+                budget : number of agents used
+                all_runs : the episode length of all runs of all agents
+                fidelity : the used fidelities in this evaluation
         """
         self.rng = rng_helper.get_rng(rng=rng, self_rng=self.rng)
         tf.random.set_random_seed(self.rng.randint(1, 100000))
@@ -185,14 +187,15 @@ class CartpoleBase(AbstractBenchmark):
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._check_fidelity
     def objective_function_test(self, configuration: Union[Dict, CS.Configuration],
-                                fidelity: Optional[Dict] = None,
+                                fidelity: Union[Dict, None] = None,
                                 rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
         """
         Validate a configuration on the cartpole benchmark. Use the full budget.
         Parameters
         ----------
         configuration : Dict, CS.Configuration
-        budget : int, None
+        fidelity: Dict, None
+            Fidelity parameters, check get_fidelity_space(). Uses default (max) value if None.
         rng : np.random.RandomState, int, None
             Random seed to use in the benchmark. To prevent overfitting on a single seed, it is possible to pass a
             parameter ``rng`` as 'int' or 'np.random.RandomState' to this function.
@@ -204,10 +207,13 @@ class CartpoleBase(AbstractBenchmark):
         Dict -
             function_value : average episode length
             cost : time to run all agents
-            max_episodes : the maximum length of an episode
-            budget : number of agents used
-            all_runs : the episode length of all runs of all agents
+            info : Dict
+                max_episodes : the maximum length of an episode
+                budget : number of agents used
+                all_runs : the episode length of all runs of all agents
+                fidelity : the used fidelities in this evaluation
         """
+
         return self.objective_function(configuration=configuration, fidelity=fidelity, rng=rng,
                                        **kwargs)
 

--- a/hpolib/benchmarks/rl/learna_benchmark.py
+++ b/hpolib/benchmarks/rl/learna_benchmark.py
@@ -174,7 +174,7 @@ class BaseLearna(AbstractBenchmark):
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
     def objective_function(self, configuration: Union[Dict, CS.Configuration],
-                           fidelity: Dict = None,
+                           fidelity: Union[Dict, None] = None,
                            rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
         """ Interface for the obejctive function. """
         raise NotImplementedError()
@@ -182,7 +182,7 @@ class BaseLearna(AbstractBenchmark):
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
     def objective_function_test(self, configuration: Union[Dict, CS.Configuration],
-                                fidelity: Dict = None,
+                                fidelity: Union[Dict, None] = None,
                                 rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
         """ Interface for the test obejctive function. """
         raise NotImplementedError()
@@ -250,7 +250,7 @@ class BaseLearna(AbstractBenchmark):
         fidel_space = CS.ConfigurationSpace(seed=seed)
 
         fidel_space.add_hyperparameters([
-            CS.UniformFloat('cutoff_agent_per_sequence', lower=1, upper=600, default_value=600)
+            CS.UniformIntegerHyperparameter('cutoff_agent_per_sequence', lower=1, upper=600, default_value=600)
         ])
 
         return fidel_space
@@ -297,7 +297,7 @@ class Learna(BaseLearna):
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._check_fidelity
     def objective_function(self, configuration: Union[Dict, CS.Configuration],
-                           fidelity: Dict = None,
+                           fidelity: Union[Dict, None] = None,
                            rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
         """
         Start the learna experiment. Dont train a RL agent. Just optimize on the sequences.
@@ -320,8 +320,10 @@ class Learna(BaseLearna):
         Dict -
             function_value : sum of min distances
             cost : time to train and evaluate the model
-            num_solved : int - number of soved sequences
-            sum_of_first_distances : metric describing quality of result
+            info : Dict
+                num_solved : int - number of soved sequences
+                sum_of_first_distances : metric describing quality of result
+                fidelity : the used fidelities in this evaluation
         """
 
         self.rng = rng_helper.get_rng(rng, self_rng=self.rng)
@@ -350,7 +352,7 @@ class Learna(BaseLearna):
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._check_fidelity
     def objective_function_test(self, configuration: Union[Dict, CS.Configuration],
-                                fidelity: Dict = None,
+                                fidelity: Union[Dict, None] = None,
                                 rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
         """
         Validate the Learna experiment.
@@ -373,8 +375,10 @@ class Learna(BaseLearna):
         Dict -
             function_value : sum of min distances
             cost : time to train and evaluate the model
-            num_solved : int - number of soved sequences
-            sum_of_first_distances : metric describing quality of result
+            info : Dict
+                num_solved : int - number of soved sequences
+                sum_of_first_distances : metric describing quality of result
+                fidelity : the used fidelities in this evaluation
         """
         return self.objective_function(configuration=configuration, fidelity=fidelity, rng=rng,
                                        **kwargs)
@@ -403,7 +407,7 @@ class MetaLearna(BaseLearna):
         fidel_space = CS.ConfigurationSpace(seed=seed)
 
         fidel_space.add_hyperparameters([
-            CS.UniformFloat('cutoff_agent_per_sequence', lower=1, upper=3600, default_value=3600)
+            CS.UniformIntegerHyperparameter('cutoff_agent_per_sequence', lower=1, upper=3600, default_value=3600)
         ])
 
         return fidel_space
@@ -411,7 +415,7 @@ class MetaLearna(BaseLearna):
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
     def objective_function(self, configuration: Union[Dict, CS.Configuration],
-                           fidelity: Dict = None,
+                           fidelity: Union[Dict, None] = None,
                            rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
         """
         MetaLearna trains an RL agent for 1 hour on the given training set and then tries to solve the sequences.
@@ -435,8 +439,10 @@ class MetaLearna(BaseLearna):
         Dict -
             function_value : sum of min distances
             cost : time to train and evaluate the model
-            num_solved : int - number of soved sequences
-            sum_of_first_distances : metric describing quality of result
+            info : Dict
+                num_solved : int - number of solved sequences
+                sum_of_first_distances : metric describing quality of result
+                fidelity : the used fidelities in this evaluation
         """
         self.rng = rng_helper.get_rng(rng, self.rng)
         tmp_dir = Path(tempfile.mkdtemp(dir=self.config.cache_dir))
@@ -472,7 +478,7 @@ class MetaLearna(BaseLearna):
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
     def objective_function_test(self, configuration: Union[Dict, CS.Configuration],
-                                fidelity: Dict = None,
+                                fidelity: Union[Dict, None] = None,
                                 rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
         """
         Validate the MetaLearna experiment.
@@ -495,8 +501,10 @@ class MetaLearna(BaseLearna):
         Dict -
             function_value : sum of min distances
             cost : time to train and evaluate the model
-            num_solved : int - number of soved sequences
-            sum_of_first_distances : metric describing quality of result
+            info : Dict
+                num_solved : int - number of solved sequences
+                sum_of_first_distances : metric describing quality of result
+                fidelity : the used fidelities in this evaluation
         """
         return self.objective_function(configuration=configuration, fidelity=fidelity, rng=rng,
                                        **kwargs)

--- a/hpolib/config.py
+++ b/hpolib/config.py
@@ -39,7 +39,7 @@ class HPOlibConfig:
                          'socket_dir': self.socket_dir,
                          'container_dir': self.cache_dir / f'hpolib3-{os.getuid()}',
                          # Find all hosted container on:
-                         # https://cloud.sylabs.io/library/keggensperger/automl
+                         # https://cloud.sylabs.io/library/phmueller/automl
                          'container_source': 'library://phmueller/automl',
                          'use_global_data': True,
                          'pyro_connect_max_wait': 400}

--- a/hpolib/container/client_abstract_benchmark.py
+++ b/hpolib/container/client_abstract_benchmark.py
@@ -370,7 +370,7 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
         # self.benchmark._pyroRelease()
 
     @staticmethod
-    def _id_generator(self) -> str:
+    def _id_generator() -> str:
         """ Helper function: Creates unique socket ids for the benchmark server """
         return str(uuid1())
 

--- a/hpolib/container/client_abstract_benchmark.py
+++ b/hpolib/container/client_abstract_benchmark.py
@@ -170,10 +170,10 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
             else:
                 logger.debug(f'Could not start instance: Try {num_tries + 1}|{MAX_TRIES}')
                 if num_tries + 1 == MAX_TRIES:
-                    raise SystemError('Could not start a instance of the benchmark. '
-                                      'Retried %d times' % MAX_TRIES)
+                    raise SystemError(f'Could not start a instance of the benchmark. Retried {MAX_TRIES:d} times'
+                                      f'\nStdout: {output} \nStderr: {err}')
             st = np.random.randint(1, 60)
-            logger.critical(f"[{num_tries + 1}/{MAX_TRIES}] Could not start instance, sleeping for {st} seconds")
+            logger.critical(f'[{num_tries + 1}/{MAX_TRIES}] Could not start instance, sleeping for {st} seconds')
             time.sleep(st)
 
         # Give each instance a little bit time to start

--- a/hpolib/container/recipes/ml/Singularity.XGBoostBenchmark
+++ b/hpolib/container/recipes/ml/Singularity.XGBoostBenchmark
@@ -9,9 +9,9 @@ VERSION v0.0.1
     apt update -y \
     && apt install build-essential git -y \
     && cd /home \
-    && git clone https://github.com/PhMueller/HPOlib3.git \
+    && git clone https://github.com/automl/HPOlib3.git \
     && cd HPOlib3 \
-    && git checkout Interface \
+    && git checkout development \
     && pip install .[singularity,xgboost] \
     && cd / \
     && mkdir /var/lib/hpolib3/ \

--- a/hpolib/container/recipes/ml/Singularity.XGBoostBenchmark
+++ b/hpolib/container/recipes/ml/Singularity.XGBoostBenchmark
@@ -11,7 +11,7 @@ VERSION v0.0.1
     && cd /home \
     && git clone https://github.com/automl/HPOlib3.git \
     && cd HPOlib3 \
-    && git checkout development \
+    && git checkout master \
     && pip install .[singularity,xgboost] \
     && cd / \
     && mkdir /var/lib/hpolib3/ \

--- a/hpolib/container/recipes/ml/Singularity.XGBoostBenchmark
+++ b/hpolib/container/recipes/ml/Singularity.XGBoostBenchmark
@@ -9,9 +9,9 @@ VERSION v0.0.1
     apt update -y \
     && apt install build-essential git -y \
     && cd /home \
-    && git clone https://github.com/automl/HPOlib3.git \
+    && git clone https://github.com/PhMueller/HPOlib3.git \
     && cd HPOlib3 \
-    && git checkout master \
+    && git checkout Interface \
     && pip install .[singularity,xgboost] \
     && cd / \
     && mkdir /var/lib/hpolib3/ \

--- a/hpolib/container/server_abstract_benchmark.py
+++ b/hpolib/container/server_abstract_benchmark.py
@@ -65,7 +65,7 @@ class BenchmarkServer:
                     (rnd0, rnd1, rnd2, rnd3, rnd4) = kwargs['rng']
                     rnd1 = [np.uint32(number) for number in rnd1]
                     kwargs['rng'] = np.random.set_state((rnd0, rnd1, rnd2, rnd3, rnd4))
-                    logger.debug('rng works!!')
+                    logger.debug('Server: Rng works')
                 self.benchmark = Benchmark(**kwargs)  # noqa: F821
             else:
                 self.benchmark = Benchmark()  # noqa: F821
@@ -75,10 +75,9 @@ class BenchmarkServer:
 
     def get_configuration_space(self, kwargs_str: str) -> str:
         logger.debug(f'Server: get_config_space: kwargs_str: {kwargs_str}')
-        seed = None
-        if kwargs_str != "{}":
-            kwargs = json.loads(kwargs_str)
-            seed = kwargs.get('seed', None)
+
+        kwargs = json.loads(kwargs_str)
+        seed = kwargs.get('seed', None)
 
         result = self.benchmark.get_configuration_space(seed=seed)
         logger.debug(f'Server: Configspace: {result}')
@@ -86,46 +85,48 @@ class BenchmarkServer:
 
     def get_fidelity_space(self, kwargs_str: str) -> str:
         logger.debug(f'Server: get_fidelity_space: kwargs_str: {kwargs_str}')
-        seed = None
-        if kwargs_str != "{}":
-            kwargs = json.loads(kwargs_str)
-            seed = kwargs.get('seed', None)
+
+        kwargs = json.loads(kwargs_str)
+        seed = kwargs.get('seed', None)
 
         result = self.benchmark.get_fidelity_space(seed=seed)
         logger.debug(f'Server: Fidelity Space: {result}')
         return csjson.write(result, indent=None)
 
-    def objective_function_list(self, c_str: str, kwargs_str: str) -> str:
+    def objective_function_list(self, c_str: str, f_str: str, kwargs_str: str) -> str:
         configuration = json.loads(c_str)
-        result = self.benchmark.objective_function(configuration, **json.loads(kwargs_str))
-        return json.dumps(result, indent=None, cls=BenchmarkEncoder)
-
-    def objective_function(self, c_str: str, kwargs_str: str) -> str:
-        logger.debug(f'Server: objective_function: c_str: {c_str} kwargs_str: {kwargs_str}')
-
-        configuration = json.loads(c_str)
+        fidelity = json.loads(f_str)
         kwargs = json.loads(kwargs_str)
 
-        rng = kwargs.get('rng', None)
-
-        if rng is not None:
-            del kwargs['rng']
-            result = self.benchmark.objective_function(configuration, rng=rng, **kwargs)
-        else:
-            result = self.benchmark.objective_function(configuration, **kwargs)
-
+        result = self.benchmark.objective_function(configuration=configuration, fidelity=fidelity, **kwargs)
         return json.dumps(result, indent=None, cls=BenchmarkEncoder)
 
-    def objective_function_test_list(self, c_str, kwargs_str):
+    def objective_function_test_list(self, c_str: str, f_str: str, kwargs_str: str) -> str:
         configuration = json.loads(c_str)
-        result = self.benchmark.objective_function_test(configuration, **json.loads(kwargs_str))
+        fidelity = json.loads(f_str)
+        kwargs = json.loads(kwargs_str)
+
+        result = self.benchmark.objective_function_test(configuration=configuration, fidelity=fidelity, **kwargs)
         return json.dumps(result, indent=None, cls=BenchmarkEncoder)
 
-    def objective_function_test(self, c_str, kwargs_str):
-        logger.debug(f'Server: objective_function: c_str: {c_str} kwargs_str: {kwargs_str}')
+    def objective_function(self, c_str: str, f_str: str, kwargs_str: str) -> str:
+        logger.debug(f'Server: objective_function: c_str: {c_str} f_str: {f_str} kwargs_str: {kwargs_str}')
 
         configuration = json.loads(c_str)
-        result = self.benchmark.objective_function_test(configuration, **json.loads(kwargs_str))
+        fidelity = json.loads(f_str)
+        kwargs = json.loads(kwargs_str)
+
+        result = self.benchmark.objective_function(configuration=configuration, fidelity=fidelity, **kwargs)
+        return json.dumps(result, indent=None, cls=BenchmarkEncoder)
+
+    def objective_function_test(self, c_str: str, f_str: str, kwargs_str: str) -> str:
+        logger.debug(f'Server: objective_function: c_str: {c_str} f_str: {f_str} kwargs_str: {kwargs_str}')
+
+        configuration = json.loads(c_str)
+        fidelity = json.loads(f_str)
+        kwargs = json.loads(kwargs_str)
+
+        result = self.benchmark.objective_function_test(configuration=configuration, fidelity=fidelity, **kwargs)
         return json.dumps(result, indent=None, cls=BenchmarkEncoder)
 
     def get_meta_information(self):


### PR DESCRIPTION
- Unifies the Interface across all benchmarks
- Stores Lock files in the temp folder. I dont remove them after usage. See the discussion in [oslo.concurrency](https://docs.openstack.org/oslo.concurrency/latest/admin/index.html#why-don-t-you-use-some-other-method-of-interprocess-locking)
- Fix a version error for pandas. There was a "0."  missing. 
- Rearranged the wrapper function for the check_configuration and check_fidelity. 
  This should simplify the workflow.
- The server supports now the fidelities. 