### PR TITLE
HPOlibrc

### DIFF
--- a/hpolib/config.py
+++ b/hpolib/config.py
@@ -1,10 +1,11 @@
 import ast
-import configparser
 import logging
 import os
-from io import StringIO
 from pathlib import Path
-from typing import Union, Any
+
+import yaml
+
+from hpolib import __version__
 
 
 class HPOlibConfig:
@@ -22,31 +23,43 @@ class HPOlibConfig:
         self.logger = logging.getLogger('HPOlibConfig')
 
         # According to https://github.com/openml/openml-python/issues/884, try to set default directories.
-        self.config_base_dir = Path(os.environ.get('XDG_CONFIG_HOME', '~/.config/hpolib2')).expanduser()
-        self.config_file = self.config_base_dir / '.hpolibrc'
+        config_base_dir = Path(os.environ.get('XDG_CONFIG_HOME', '~/.config/hpolib2')).expanduser()
+
+        # The path to the hpolibrc file
+        self.config_file = config_base_dir / '.hpolibrc'
+        self.config_file = self.config_file.expanduser().absolute()
+
+        # The configuration file should have the same version as the hpolib. Raise a warning if there is a version
+        # mismatch. We want to make sure that the configuration file is up to date with the hpolib, because it is
+        # possible that something in the configuration has changed but the old hpolibrc file is still there and prohibit
+        # the changes. Ignore the dev tag if available.
+        self.config_version = __version__.rstrip('dev')
+
+        # Set the default logging level.
+        # Possible levels are 0 = NOTSET (warning), 10 = DEBUG, 20 = INFO, 30 = WARNING, 40 = ERROR, 50 = CRITICAL
+        # See also https://docs.python.org/3/library/logging.html#logging-levels
+        self.verbosity = 0
+
+        # The cache dir contains the lock files etc
         self.cache_dir = Path(os.environ.get('XDG_CACHE_HOME', '~/.cache/hpolib2')).expanduser()
+
+        # The user can specify if the local or a more global data directory should be used. This is helpful when working
+        # on a cluster
+        self.data_dir = config_base_dir
         self.global_data_dir = Path(os.environ.get('XDG_DATA_HOME', '~/.local/share/hpolib2')).expanduser()
+        self.use_global_data = True
 
-        self.config = None
-        self.data_dir = None
-        self.socket_dir = Path("/tmp")
-        self.container_dir = None
-        self.container_source = None
-        self.use_global_data = None
+        # Options for the singularity container
+        # Find all hosted container on: https://cloud.sylabs.io/library/phmueller/automl
+        self.socket_dir = Path('/tmp')
+        self.container_dir = self.cache_dir / f'hpolib2-{os.getuid()}'
+        self.container_source = 'library://phmueller/automl'
+        self.pyro_connect_max_wait = 400
 
-        self.defaults = {'verbosity': 0,
-                         'data_dir': self.config_base_dir,
-                         'socket_dir': self.socket_dir,
-                         'container_dir': self.cache_dir / f'hpolib2-{os.getuid()}',
-                         # Find all hosted container on:
-                         # https://cloud.sylabs.io/library/phmueller/automl
-                         'container_source': 'library://phmueller/automl',
-                         'use_global_data': True,
-                         'pyro_connect_max_wait': 400}
+        # Read in the hpolibrc file and set the default values if not specified
+        self._setup()
 
-        self._setup(self.config_file)
-
-    def _setup(self, config_file: Union[Path, str]):
+    def _setup(self):
         """ Sets up config. Reads the config file and parses it.
 
         Parameters:
@@ -56,18 +69,11 @@ class HPOlibConfig:
             Path to config file
         """
 
-        # Change current config file to new config file
-        config_file = Path(config_file).expanduser().absolute()
-
-        if config_file != self.config_file:
-            self.logger.debug(f'Change config file from {self.config_file} to {config_file}')
-            self.config_file = config_file
-
         # Create an empty config file if there was none so far
         if not self.config_file.exists():
             self.__create_config_file()
 
-        # Parse config and store input in self.config
+        # Parse config
         self.__parse_config()
 
         # Check whether data_dir exists, if not create it
@@ -79,51 +85,67 @@ class HPOlibConfig:
 
     def __create_config_file(self):
         """ Create the configuration file. """
-        try:
-            self.logger.debug(f'Create a new config file here: {self.config_file}')
-            self.__check_dir(self.config_file.parent)
-            fh = self.config_file.open('w', encoding='utf-8')
-            for k in self.defaults:
-                fh.write(f'{k}={self.defaults[k]}\n')
-            fh.close()
-        except (IOError, OSError):
-            raise
+        self.logger.debug(f'Create a new config file here: {self.config_file}')
+        self.__check_dir(self.config_file.parent)
+
+        defaults = {'version': self.config_version,
+                    'verbosity': self.verbosity,
+                    'cache_dir': str(self.cache_dir),
+                    'data_dir': str(self.data_dir),
+                    'global_data_dir': str(self.global_data_dir),
+                    'use_global_data': True,
+                    'socket_dir': str(self.socket_dir),
+                    'container_dir': str(self.container_dir),
+                    'container_source': self.container_source,
+                    'pyro_connect_max_wait': self.pyro_connect_max_wait
+                    }
+
+        with self.config_file.open('w', encoding='utf-8') as fh:
+            yaml.dump(defaults, fh)
 
     def __parse_config(self):
         """ Parse the config file """
-        config = configparser.RawConfigParser()
+        with self.config_file.open('r') as fh:
+            read_config = yaml.load(fh, Loader=yaml.FullLoader)
 
-        # Cheat the ConfigParser module by adding a fake section header
-        config_file_ = StringIO()
-        config_file_.write('[FAKE_SECTION]\n')
-        with self.config_file.open('r', encoding='utf-8') as fh:
-            for line in fh:
-                config_file_.write(line)
-        config_file_.seek(0)
-        config.read_file(config_file_)
-        self.config = config
+        # The old hpolibrc was parsed with the configparser. But this required to use fake sections, etc. We moved to
+        # pyyaml. Yaml returns a string if the rc file is not in yaml format.
+        if isinstance(read_config, str):
+            logging.warning('The hpolibrc can not be parsed. This is likely due to a change in the hpolibrc format.'
+                            f' Please remove the old hpolibrc. The hpolibrc file is in {self.config_file}')
 
-        # Store configuration
-        self.data_dir = Path(self.__get_config_option('data_dir'))
-        self.socket_dir = Path(self.__get_config_option('socket_dir'))
-        self.container_dir = Path(self.__get_config_option('container_dir'))
-        self.container_source = self.__get_config_option('container_source')
-        self.use_global_data = self.__get_config_option('use_global_data')
-        if type(self.use_global_data) is str:
+        self.config_version = read_config.get('version')
+        self._check_version()
+
+        self.verbosity = read_config.get('verbosity', self.verbosity)
+        logging.basicConfig(level=self.verbosity)
+
+        self.cache_dir = Path(read_config.get('cache_dir', self.cache_dir))
+        self.data_dir = Path(read_config.get('data_dir', self.data_dir))
+        self.global_data_dir = Path(read_config.get('global_data_dir', self.global_data_dir))
+        self.use_global_data = read_config.get('use_global_data', self.use_global_data)
+
+        if isinstance(self.use_global_data, str):
             self.use_global_data = ast.literal_eval(self.use_global_data)
-        self.pyro_connect_max_wait = int(self.__get_config_option('pyro_connect_max_wait'))
 
-        # Use global data dir if exist
         if self.global_data_dir.is_dir() and self.use_global_data:
             self.data_dir = self.global_data_dir
 
-    def __get_config_option(self, o: str) -> Any:
-        """ Try to get config option from configuration file. If the option is
-            not configured, use default """
-        try:
-            return self.config.get('FAKE_SECTION', o)
-        except configparser.NoOptionError:
-            return self.defaults[o]
+        self.socket_dir = Path(read_config.get('socket_dir', self.socket_dir))
+        self.container_dir = Path(read_config.get('container_dir', self.container_dir))
+        self.container_source = read_config.get('container_source', self.container_source)
+        self.pyro_connect_max_wait = int(read_config.get('pyro_connect_max_wait',
+                                                         self.pyro_connect_max_wait))
+
+    def _check_version(self):
+        """ Check if the version of the configuration file matches the hpolib version.
+            Ignore the `dev` tag at the end.
+        """
+        if self.config_version is None or not __version__.startswith(self.config_version):
+            self.config_version = self.config_version if not None else 'None'
+            logging.warning(f'The hpolibrc file was created with another version of the hpolib. '
+                            f'Current version of the hpolibrc file: {self.config_version}.\n'
+                            f'Current version of the hpolib: {__version__}')
 
     def __check_dir(self, path: Path):
         """ Check whether dir exists and if not create it"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy>=1.18.1
 ConfigSpace>=0.4.12
 Pyro4==4.80
 oslo.concurrency>=4.2.0
+pyyaml>=5.0.0

--- a/tests/test_hpolibrc.py
+++ b/tests/test_hpolibrc.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def test_config_file():
+    from hpolib import config_file
+    assert config_file.verbosity == 0
+    assert config_file.config_version == '0.0.5'
+    assert config_file.data_dir == Path('~/.local/share/hpolib2').expanduser().absolute()
+    assert config_file.container_dir == Path('~/.cache/hpolib2/hpolib2-1000').expanduser().absolute()
+    assert config_file.container_source == 'library://phmueller/automl'
+    assert config_file.use_global_data
+    assert config_file.pyro_connect_max_wait == 400


### PR DESCRIPTION
* Add a version check mechanism for the configuration file and the hpolib version
- if there is a mismatch, just raise an warning

* Change the configuration file read/write from config parser to yaml:
- I have used the opportunity to simplify the hpolibrc. It used a configparser, which required to write some fake header and stuff. 
- the pyyaml module is already installed for a lot of packages. So it is no new extra dependency. 