### PR TITLE
Fix pybnn/nasbench201epochs

### DIFF
--- a/hpolib/benchmarks/ml/pybnn.py
+++ b/hpolib/benchmarks/ml/pybnn.py
@@ -9,16 +9,22 @@ you need to install the following packages besides installing the hpolib with
 ```pip install .[pybnn]```
 
 """
-import time
 from functools import partial
-
+import logging
+import os
+import time
+from typing import Union, Dict, Any
 
 import numpy as np
 from scipy import stats
+
+import ConfigSpace as CS  # noqa
+
+from hpolib.util.data_manager import BostonHousingData, ProteinStructureData, YearPredictionMSDData
+from hpolib.abstract_benchmark import AbstractBenchmark
 from hpolib.util import rng_helper
 
 # This has to happen before any other imports
-import os
 if "TMPDIR" not in os.environ:
     import tempfile
     tmpdir = tempfile.TemporaryDirectory()
@@ -27,18 +33,10 @@ else:
     tmpdir_name = os.environ["TMPDIR"]
 os.environ["THEANO_FLAGS"] = "base_compiledir=%s" % tmpdir_name
 
-import lasagne
+import lasagne  # noqa
+from sgmcmc.bnn.model import BayesianNeuralNetwork  # noqa
+from sgmcmc.bnn.lasagne_layers import AppendLayer  # noqa
 
-import ConfigSpace as CS
-
-from sgmcmc.bnn.model import BayesianNeuralNetwork
-from sgmcmc.bnn.lasagne_layers import AppendLayer
-from typing import Union, Dict, Any
-
-from hpolib.util.data_manager import BostonHousingData, ProteinStructureData, YearPredictionMSDData
-from hpolib.abstract_benchmark import AbstractBenchmark
-
-import logging
 
 __version__ = '0.0.1'
 

--- a/hpolib/benchmarks/ml/pybnn.py
+++ b/hpolib/benchmarks/ml/pybnn.py
@@ -16,6 +16,17 @@ from functools import partial
 import numpy as np
 from scipy import stats
 from hpolib.util import rng_helper
+
+# This has to happen before any other imports
+import os
+if "TMPDIR" not in os.environ:
+    import tempfile
+    tmpdir = tempfile.TemporaryDirectory()
+    tmpdir_name = tmpdir.name
+else:
+    tmpdir_name = os.environ["TMPDIR"]
+os.environ["THEANO_FLAGS"] = "base_compiledir=%s" % tmpdir_name
+
 import lasagne
 
 import ConfigSpace as CS

--- a/hpolib/benchmarks/ml/pybnn.py
+++ b/hpolib/benchmarks/ml/pybnn.py
@@ -264,7 +264,7 @@ class BayesianNeuralNetworkBenchmark(AbstractBenchmark):
         fidel_space = CS.ConfigurationSpace(seed=seed)
 
         fidel_space.add_hyperparameters([
-            CS.UniformIntegerHyperparameter("budget", lower=100, upper=10000, default_value=10000, log=False)
+            CS.UniformIntegerHyperparameter("budget", lower=500, upper=10000, default_value=10000, log=False)
         ])
 
         return fidel_space

--- a/hpolib/benchmarks/ml/pybnn.py
+++ b/hpolib/benchmarks/ml/pybnn.py
@@ -9,39 +9,36 @@ you need to install the following packages besides installing the hpolib with
 ```pip install .[pybnn]```
 
 """
-import time
 from functools import partial
-
+import logging
+import os
+import time
+import tempfile
+from typing import Union, Dict, Any
 
 import numpy as np
 from scipy import stats
+
+import ConfigSpace as CS
+
+from hpolib.util.data_manager import BostonHousingData, ProteinStructureData, YearPredictionMSDData
+from hpolib.abstract_benchmark import AbstractBenchmark
 from hpolib.util import rng_helper
 
 # This has to happen before any other imports
-import os
 if "TMPDIR" not in os.environ:
-    import tempfile
     tmpdir = tempfile.TemporaryDirectory()
     tmpdir_name = tmpdir.name
 else:
     tmpdir_name = os.environ["TMPDIR"]
-os.environ["THEANO_FLAGS"] = "base_compiledir=%s" % tmpdir_name
+os.environ["THEANO_FLAGS"] = f"base_compiledir={tmpdir_name}"
 
-import lasagne
+import lasagne  # noqa: E402
+from sgmcmc.bnn.model import BayesianNeuralNetwork  # noqa: E402
+from sgmcmc.bnn.lasagne_layers import AppendLayer  # noqa: E402
 
-import ConfigSpace as CS
 
-from sgmcmc.bnn.model import BayesianNeuralNetwork
-from sgmcmc.bnn.lasagne_layers import AppendLayer
-from typing import Union, Dict, Any
-
-from hpolib.util.data_manager import BostonHousingData, ProteinStructureData, YearPredictionMSDData
-from hpolib.abstract_benchmark import AbstractBenchmark
-
-import logging
-
-__version__ = '0.0.1'
-
+__version__ = '0.0.2'
 logger = logging.getLogger('PyBnnBenchmark')
 
 

--- a/hpolib/benchmarks/ml/svm_benchmark.py
+++ b/hpolib/benchmarks/ml/svm_benchmark.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from typing import Union, Tuple, Dict, List
 
@@ -16,8 +17,6 @@ from hpolib.abstract_benchmark import AbstractBenchmark
 from hpolib.util.openml_data_manager import OpenMLHoldoutDataManager
 
 __version__ = '0.0.1'
-
-import logging
 
 logger = logging.getLogger('SVMBenchmark')
 

--- a/hpolib/benchmarks/nas/nasbench_201.py
+++ b/hpolib/benchmarks/nas/nasbench_201.py
@@ -193,7 +193,6 @@ class NasBench201BaseBenchmark(AbstractBenchmark):
                 fidelity : Dict
                     used fidelities in this evaluation
         """
-
         # Check if the data set seeds are valid
         assert isinstance(data_seed, List) or isinstance(data_seed, Tuple) or isinstance(data_seed, int), \
             f'data seed has unknown data type {type(data_seed)}, but should be tuple or int (777,888,999)'
@@ -212,7 +211,7 @@ class NasBench201BaseBenchmark(AbstractBenchmark):
         structure = self.config_to_structure(configuration)
         structure_str = structure.tostr()
 
-        epoch = fidelity['epoch']
+        epoch = fidelity['epoch'] - 1
 
         train_accuracies = [self.data[(seed, 'train_acc1es')][structure_str][epoch] for seed in data_seed]
         train_losses = [self.data[(seed, 'train_losses')][structure_str][epoch] for seed in data_seed]
@@ -279,9 +278,10 @@ class NasBench201BaseBenchmark(AbstractBenchmark):
                 fidelity : used fidelities in this evaluation
         """
 
-        # The result dict should contain already all necessary information -> Just swap the function value from valid
-        # to test and the corresponding time cost
-        result = self.objective_function(configuration=configuration, fidelity=fidelity, data_seed=(777, 888, 999),
+        # The result dict should contain already all necessary information ->
+        # Just swap the function value from valid to test and the corresponding time cost
+        result = self.objective_function(configuration=configuration, fidelity=fidelity,
+                                         data_seed=(777, 888, 999),
                                          rng=rng, **kwargs)
         result['function_value'] = result['info']['eval_precision']
         result['cost'] = result['info']['eval_cost']
@@ -364,7 +364,7 @@ class NasBench201BaseBenchmark(AbstractBenchmark):
         fidel_space = CS.ConfigurationSpace(seed=seed)
 
         fidel_space.add_hyperparameters([
-            CS.UniformIntegerHyperparameter('epoch', lower=0, upper=199, default_value=199)
+            CS.UniformIntegerHyperparameter('epoch', lower=1, upper=200, default_value=200)
         ])
 
         return fidel_space


### PR DESCRIPTION
This PR does the following:
  * PyBNN uses theano which locks a compile directory every evaluation. Running several benchmarks in parallel causes delay. I  set the compile directory to the content of $TMPDIR or create a new tmpdir
  * The original PyBNN benchmark uses fidelity 500 to 10000, I fixed this
  * NasBench201 uses epochs 0 to 199 as a fidelity. Setting the fidelity to 0 causes problems with many optimizers. I changed the epochs to be in [1, 200] and internally decrease this value by 1

Unfortunately, we need to rebuild containers for this ...
