### PR TITLE
Large update

### DIFF
--- a/ci_scripts/codestyle.sh
+++ b/ci_scripts/codestyle.sh
@@ -20,17 +20,14 @@ if [[ "$RUN_CODESTYLE" == "true" ]]; then
     fi
 
     # Enable the error W0221: Parameters differ from overridden method (arguments-differ)
-    test_pylint=$(pylint --disable=all --enable=W0221 ./hpobench)
-    if [[ $test_pylint ]]; then
-      echo $test_pylint
-      exit 1
+    pylint --disable=all --enable=W0221 ./hpobench
+    exit_code=$?
+    if [[ "$exit_code" -eq 0 ]]; then
+        echo "Pylint: No signature errors found"
     else
-      echo "Pylint: No signature errors found"
+        echo "Pylint: Signature Failure!"
+        exit 1
     fi
-
-    # Just print the pylint output without throwing an error.
-    pylint --exit-zero --rcfile=./pylint.rc ./hpolib
-
 else
     echo "Skip code style checking"
 fi

--- a/ci_scripts/codestyle.sh
+++ b/ci_scripts/codestyle.sh
@@ -20,7 +20,7 @@ if [[ "$RUN_CODESTYLE" == "true" ]]; then
     fi
 
     # Enable the error W0221: Parameters differ from overridden method (arguments-differ)
-    test_pylint=$(pylint --disable=all --enable=W0221 ./hpolib)
+    test_pylint=$(pylint --disable=all --enable=W0221 ./hpobench)
     if [[ $test_pylint ]]; then
       echo $test_pylint
       exit 1

--- a/ci_scripts/codestyle.sh
+++ b/ci_scripts/codestyle.sh
@@ -18,6 +18,19 @@ if [[ "$RUN_CODESTYLE" == "true" ]]; then
     else
       echo "Flake8: No errors found"
     fi
+
+    # Enable the error W0221: Parameters differ from overridden method (arguments-differ)
+    test_pylint=$(pylint --disable=all --enable=W0221 ./hpolib)
+    if [[ $test_pylint ]]; then
+      echo $test_pylint
+      exit 1
+    else
+      echo "Pylint: No signature errors found"
+    fi
+
+    # Just print the pylint output without throwing an error.
+    pylint --exit-zero --rcfile=./pylint.rc ./hpolib
+
 else
     echo "Skip code style checking"
 fi

--- a/ci_scripts/install.sh
+++ b/ci_scripts/install.sh
@@ -12,7 +12,7 @@ fi
 
 if [[ "$RUN_CODESTYLE" == "true" ]]; then
     echo "Install tools for codestyle checking"
-    install_packages="${install_packages}codestyle,pylint,"
+    install_packages="${install_packages}codestyle,"
 else
     echo "Skip installing tools for codestyle checking"
 fi

--- a/ci_scripts/install.sh
+++ b/ci_scripts/install.sh
@@ -12,7 +12,7 @@ fi
 
 if [[ "$RUN_CODESTYLE" == "true" ]]; then
     echo "Install tools for codestyle checking"
-    install_packages="${install_packages}codestyle,"
+    install_packages="${install_packages}codestyle,pylint,"
 else
     echo "Skip installing tools for codestyle checking"
 fi

--- a/examples/w_optimizer/cartpole_bohb.py
+++ b/examples/w_optimizer/cartpole_bohb.py
@@ -32,6 +32,7 @@ class CustomWorker(Worker):
         self.seed = seed
         self.max_budget = max_budget
 
+    # pylint: disable=arguments-differ
     def compute(self, config, budget, **kwargs):
         b = Benchmark(rng=self.seed)
         # Old API ---- NO LONGER SUPPORTED ---- This will simply ignore the fidelities

--- a/extra_requirements/tests.json
+++ b/extra_requirements/tests.json
@@ -1,5 +1,6 @@
 {
   "codestyle": ["pycodestyle","flake8"],
   "pytest": ["pytest>=4.6","pytest-cov"],
+  "pylint": ["pylint"],
   "test_paramnet": ["tqdm"]
 }

--- a/extra_requirements/tests.json
+++ b/extra_requirements/tests.json
@@ -1,6 +1,5 @@
 {
-  "codestyle": ["pycodestyle","flake8"],
+  "codestyle": ["pycodestyle","flake8","pylint"],
   "pytest": ["pytest>=4.6","pytest-cov"],
-  "pylint": ["pylint"],
   "test_paramnet": ["tqdm"]
 }

--- a/hpobench/abstract_benchmark.py
+++ b/hpobench/abstract_benchmark.py
@@ -120,7 +120,7 @@ class AbstractBenchmark(abc.ABC, metaclass=abc.ABCMeta):
 
             # Second, evaluate the given fidelities.
             # Sanity check that there are no fidelities in **kwargs
-            fidelity = self._check_and_cast_fidelity(configuration, fidelity, **kwargs)
+            fidelity = self._check_and_cast_fidelity(fidelity, **kwargs)
 
             # All benchmarks should work on dictionaries. Cast the both objects to dictionaries.
             return wrapped_function(self, configuration.get_dictionary(), fidelity.get_dictionary(), **kwargs)

--- a/hpobench/abstract_benchmark.py
+++ b/hpobench/abstract_benchmark.py
@@ -142,7 +142,7 @@ class AbstractBenchmark(abc.ABC, metaclass=abc.ABCMeta):
         self.configuration_space.check_configuration(configuration)
         return configuration
 
-    def _check_and_cast_fidelity(self, fidelity: Union[dict, ConfigSpace.Configuration], **kwargs) \
+    def _check_and_cast_fidelity(self, fidelity: Union[dict, ConfigSpace.Configuration, None], **kwargs) \
             -> ConfigSpace.Configuration:
         """ Helper-function to evaluate the given fidelity object.
             Similar to the checking and casting from above, we validate the fidelity object. To do so, we cast it to a

--- a/hpobench/abstract_benchmark.py
+++ b/hpobench/abstract_benchmark.py
@@ -1,7 +1,7 @@
 """ Base-class of all benchmarks """
 
 import abc
-from typing import Union, Dict, List
+from typing import Union, Dict
 import functools
 
 import logging

--- a/hpobench/abstract_benchmark.py
+++ b/hpobench/abstract_benchmark.py
@@ -97,135 +97,70 @@ class AbstractBenchmark(abc.ABC, metaclass=abc.ABCMeta):
         NotImplementedError()
 
     @staticmethod
-    def _check_configuration(foo):
+    def check_parameters(wrapped_function):
         """
-        Decorator to enable checking the input configuration and, if given, fidelity parameters.
+        Wrapper for the objective_function and objective_function_test.
+        This function verifies the correctness of the input configuration and the given fidelity.
 
-        Uses the check_configuration of the ConfigSpace class to ensure
-        that all specified values are valid, and no conditionals are violated
+        It ensures that both, configuration and fidelity, don't contain any wrong parameters or any conditions are
+        violated.
 
-        Can be combined with the _configuration_as_array decorator.
-        """
+        If the argument 'fidelity' is not specified or a single parameter is missing, then the corresponding default
+        fidelities are filled in.
 
-        # Copy all documentation from the underlying function except the annotations.
-        @functools.wraps(wrapped=foo, assigned=('__module__', '__name__', '__qualname__', '__doc__',))
-        def wrapper(self, configuration: Union[np.ndarray, List, ConfigSpace.Configuration, Dict], **kwargs):
-
-            try:
-                if isinstance(configuration, (np.ndarray, List)):
-                    config_dict = {k: configuration[i] for (i, k) in enumerate(self.configuration_space)}
-                    config = ConfigSpace.Configuration(self.configuration_space, config_dict)
-                elif isinstance(configuration, dict):
-                    config = ConfigSpace.Configuration(self.configuration_space, configuration)
-                elif isinstance(configuration, ConfigSpace.Configuration):
-                    config = configuration
-                else:
-                    config = None
-            except Exception as e:
-                logger.error('Error during the conversion of the provided configuration '
-                             'into a ConfigSpace.Configuration object')
-                raise e
-
-            if config is None:
-                raise TypeError(f'Configuration has to be from type np.ndarray, dict, or ConfigSpace.Configuration but '
-                                f'was {type(configuration)}')
-
-            self.configuration_space.check_configuration(config)
-            return foo(self, configuration, **kwargs)
-        return wrapper
-
-    @staticmethod
-    def _check_fidelity(foo):
-        """
-        Decorator to enable checking the input fidelity parameters, if any. Wrapped functions are expected to contain
-        an optional 'fidelity':keyword argument, which would in turn contain a dictionary of the requested fidelity
-        parameters. If any specific parameter is missing or the entire argument is missing, the corresponding default
-        values are filled in.
-
-        Uses the check_configuration of the ConfigSpace class to ensure that all specified values are valid, and no
-        conditionals are violated.
-
-        Order independent from the _check_configuration decorator, but it does forward all fidelity parameters,
-        regardless of input, as a dictionary in the 'fidelity' keyword argument.
+        We cast them to a ConfigSpace.Configuration object to ensure that no conditions are violated.
         """
 
         # Copy all documentation from the underlying function except the annotations.
-        @functools.wraps(wrapped=foo, assigned=('__module__', '__name__', '__qualname__', '__doc__',))
-        def wrapper(self, configuration: Union[np.ndarray, ConfigSpace.Configuration, Dict],
+        @functools.wraps(wrapped=wrapped_function, assigned=('__module__', '__name__', '__qualname__', '__doc__',))
+        def wrapper(self, configuration: Union[ConfigSpace.Configuration, Dict],
                     fidelity: Union[Dict, ConfigSpace.Configuration, None] = None, **kwargs):
 
+            # First, try to cast the configuration into a ConfigSpace.Configuration to test if the configuration is in
+            # the defined boundaries.
+            if isinstance(configuration, (np.ndarray, List)):
+                config_dict = {k: configuration[i] for (i, k) in enumerate(self.configuration_space)}
+                configuration = ConfigSpace.Configuration(self.configuration_space, config_dict)
+            elif isinstance(configuration, dict):
+                configuration = ConfigSpace.Configuration(self.configuration_space, configuration)
+            elif isinstance(configuration, ConfigSpace.Configuration):
+                configuration = configuration
+            else:
+                raise TypeError(
+                    f'Configuration has to be from type List, np.ndarray, dict, or ConfigSpace.Configuration but '
+                    f'was {type(configuration)}')
+            self.configuration_space.check_configuration(configuration)
+
+            # Second, evaluate the given fidelities.
             # Sanity check that there are no fidelities in **kwargs
             for f in self.fidelity_space.get_hyperparameters():
                 if f.name in kwargs:
                     raise ValueError(f'Fidelity parameter {f.name} should not be part of kwargs\n'
                                      f'Fidelity: {fidelity}\n Kwargs: {kwargs}')
 
-            # If kwargs contains the 'fidelity' arg, extract any fidelity parameters it contains and fill in
-            # default values for the rest.
             default_fidelities = self.fidelity_space.get_default_configuration()
-            try:
-                if fidelity is None:
-                    fidelity = default_fidelities
-                if isinstance(fidelity, dict):
-                    default_fidelities_cfg = default_fidelities.get_dictionary()
-                    fidelity = {k: fidelity.get(k, v) for k, v in default_fidelities_cfg.items()}
-                    fidelity = ConfigSpace.Configuration(self.fidelity_space, fidelity)
-                elif isinstance(fidelity, ConfigSpace.Configuration):
-                    pass
-                else:
-                    fidelity = None
-            except Exception as e:
-                logger.error('Error during the conversion of the provided fidelities '
-                             'into a FidelitySpace (ConfigSpace.Configuration) object')
-                raise e
-
             if fidelity is None:
-                raise TypeError(f'Fidelity has to be an instance of type np.ndarray, dict, or '
-                                f'ConfigSpace.Configuration but was {type(configuration)}')
+                fidelity = default_fidelities
+            if isinstance(fidelity, dict):
+                default_fidelities_cfg = default_fidelities.get_dictionary()
+                fidelity_copy = fidelity.copy()
+                fidelity = {k: fidelity_copy.pop(k, v) for k, v in default_fidelities_cfg.items()}
+                assert len(fidelity_copy) == 0, 'Provided fidelity dict contained unknown fidelity ' \
+                                                f'values: {fidelity_copy.keys()}'
 
+                fidelity = ConfigSpace.Configuration(self.fidelity_space, fidelity)
+            elif isinstance(fidelity, ConfigSpace.Configuration):
+                fidelity = fidelity
+            else:
+                raise TypeError(f'Fidelity has to be an instance of type None, dict, or '
+                                f'ConfigSpace.Configuration but was {type(configuration)}')
             # Ensure that the extracted fidelity values play well with the defined fidelity space
             self.fidelity_space.check_configuration(fidelity)
 
-            # All benchmarks should work on dictionaries. Cast the fidelity space object to a dictionary.
-            fidelity = fidelity.get_dictionary()
-
-            return foo(self, configuration, fidelity=fidelity, **kwargs)
+            # All benchmarks should work on dictionaries. Cast the both objects to dictionaries.
+            return wrapped_function(self, configuration.get_dictionary(), fidelity.get_dictionary(), **kwargs)
         return wrapper
 
-    @staticmethod
-    def _configuration_as_array(foo, data_type=np.float):
-        """
-        Decorator to allow the first input argument to 'objective_function' to
-        be an array.
-
-        For all continuous benchmarks it is often required that the input to
-        the benchmark can be a (NumPy) array. By adding this to the objective
-        function, both inputs types, ConfigSpace.Configuration and array,
-        are possible.
-
-        Can be combined with the _check_configuration decorator.
-        """
-        def wrapper(self, configuration, **kwargs):
-            if isinstance(configuration, ConfigSpace.Configuration):
-                config_array = np.array([configuration[k] for k in configuration], dtype=data_type)
-            else:
-                config_array = configuration
-            return foo(self, config_array, **kwargs)
-        return wrapper
-
-    @staticmethod
-    def _configuration_as_dict(foo):
-        """
-        Decorator to cast the ConfigSpace.configuration to a dictionary. This allows the first argument of
-        objective_function and objective_function_test to be a ConfigSpace.configuration.
-
-        Can be combined with the _check_configuration decorator.
-        """
-        def wrapper(self, configuration, **kwargs):
-            if isinstance(configuration, ConfigSpace.Configuration):
-                configuration = configuration.get_dictionary()
-            return foo(self, configuration, **kwargs)
-        return wrapper
 
     def __call__(self, configuration: Dict, **kwargs) -> float:
         """ Provides interface to use, e.g., SciPy optimizers """

--- a/hpobench/abstract_benchmark.py
+++ b/hpobench/abstract_benchmark.py
@@ -116,51 +116,69 @@ class AbstractBenchmark(abc.ABC, metaclass=abc.ABCMeta):
         def wrapper(self, configuration: Union[ConfigSpace.Configuration, Dict],
                     fidelity: Union[Dict, ConfigSpace.Configuration, None] = None, **kwargs):
 
-            # First, try to cast the configuration into a ConfigSpace.Configuration to test if the configuration is in
-            # the defined boundaries.
-            if isinstance(configuration, (np.ndarray, List)):
-                config_dict = {k: configuration[i] for (i, k) in enumerate(self.configuration_space)}
-                configuration = ConfigSpace.Configuration(self.configuration_space, config_dict)
-            elif isinstance(configuration, dict):
-                configuration = ConfigSpace.Configuration(self.configuration_space, configuration)
-            elif isinstance(configuration, ConfigSpace.Configuration):
-                configuration = configuration
-            else:
-                raise TypeError(
-                    f'Configuration has to be from type List, np.ndarray, dict, or ConfigSpace.Configuration but '
-                    f'was {type(configuration)}')
-            self.configuration_space.check_configuration(configuration)
+            configuration = self._check_and_cast_configuration(configuration)
 
             # Second, evaluate the given fidelities.
             # Sanity check that there are no fidelities in **kwargs
-            for f in self.fidelity_space.get_hyperparameters():
-                if f.name in kwargs:
-                    raise ValueError(f'Fidelity parameter {f.name} should not be part of kwargs\n'
-                                     f'Fidelity: {fidelity}\n Kwargs: {kwargs}')
-
-            default_fidelities = self.fidelity_space.get_default_configuration()
-            if fidelity is None:
-                fidelity = default_fidelities
-            if isinstance(fidelity, dict):
-                default_fidelities_cfg = default_fidelities.get_dictionary()
-                fidelity_copy = fidelity.copy()
-                fidelity = {k: fidelity_copy.pop(k, v) for k, v in default_fidelities_cfg.items()}
-                assert len(fidelity_copy) == 0, 'Provided fidelity dict contained unknown fidelity ' \
-                                                f'values: {fidelity_copy.keys()}'
-
-                fidelity = ConfigSpace.Configuration(self.fidelity_space, fidelity)
-            elif isinstance(fidelity, ConfigSpace.Configuration):
-                fidelity = fidelity
-            else:
-                raise TypeError(f'Fidelity has to be an instance of type None, dict, or '
-                                f'ConfigSpace.Configuration but was {type(configuration)}')
-            # Ensure that the extracted fidelity values play well with the defined fidelity space
-            self.fidelity_space.check_configuration(fidelity)
+            fidelity = self._check_and_cast_fidelity(configuration, fidelity, **kwargs)
 
             # All benchmarks should work on dictionaries. Cast the both objects to dictionaries.
             return wrapped_function(self, configuration.get_dictionary(), fidelity.get_dictionary(), **kwargs)
         return wrapper
 
+    def _check_and_cast_configuration(self, configuration: Union[Dict, ConfigSpace.Configuration]) \
+            -> ConfigSpace.Configuration:
+        """ Helper-function to evaluate the given configuration.
+            Cast it to a ConfigSpace.Configuration and evaluate if it violates some boundaries.
+        """
+
+        if isinstance(configuration, dict):
+            configuration = ConfigSpace.Configuration(self.configuration_space, configuration)
+        elif isinstance(configuration, ConfigSpace.Configuration):
+            configuration = configuration
+        else:
+            raise TypeError(f'Configuration has to be from type List, np.ndarray, dict, or '
+                            f'ConfigSpace.Configuration but was {type(configuration)}')
+        self.configuration_space.check_configuration(configuration)
+        return configuration
+
+    def _check_and_cast_fidelity(self, fidelity: Union[dict, ConfigSpace.Configuration], **kwargs) \
+            -> ConfigSpace.Configuration:
+        """ Helper-function to evaluate the given fidelity object.
+            Similar to the checking and casting from above, we validate the fidelity object. To do so, we cast it to a
+            ConfigSpace.Configuration object.
+            If the fidelity is not specified (None), then we use the default fidelity of the benchmark.
+            If the benchmark is a multi-multi-fidelity benchmark and only a subset of the available fidelities is
+            specified, we fill the missing ones with their default values.
+        """
+        # Make a check, that no fidelities are in the kwargs.
+        f_in_kwargs = []
+        for f in self.fidelity_space.get_hyperparameters():
+            if f.name in kwargs:
+                f_in_kwargs.append(f.name)
+        if len(f_in_kwargs) != 0:
+            raise ValueError(f'Fidelity parameters {", ".join(f_in_kwargs)} should not be part of kwargs\n'
+                             f'Fidelity: {fidelity}\n Kwargs: {kwargs}')
+
+        default_fidelities = self.fidelity_space.get_default_configuration()
+
+        if fidelity is None:
+            fidelity = default_fidelities
+        if isinstance(fidelity, dict):
+            default_fidelities_cfg = default_fidelities.get_dictionary()
+            fidelity_copy = fidelity.copy()
+            fidelity = {k: fidelity_copy.pop(k, v) for k, v in default_fidelities_cfg.items()}
+            assert len(fidelity_copy) == 0, 'Provided fidelity dict contained unknown fidelity ' \
+                                            f'values: {fidelity_copy.keys()}'
+            fidelity = ConfigSpace.Configuration(self.fidelity_space, fidelity)
+        elif isinstance(fidelity, ConfigSpace.Configuration):
+            fidelity = fidelity
+        else:
+            raise TypeError(f'Fidelity has to be an instance of type None, dict, or '
+                            f'ConfigSpace.Configuration but was {type(fidelity)}')
+        # Ensure that the extracted fidelity values play well with the defined fidelity space
+        self.fidelity_space.check_configuration(fidelity)
+        return fidelity
 
     def __call__(self, configuration: Dict, **kwargs) -> float:
         """ Provides interface to use, e.g., SciPy optimizers """

--- a/hpobench/benchmarks/ml/pybnn.py
+++ b/hpobench/benchmarks/ml/pybnn.py
@@ -78,7 +78,7 @@ class BayesianNeuralNetworkBenchmark(AbstractBenchmark):
         configuration : Dict, CS.Configuration
             Configuration for the pyBNN model
         fidelity: Dict, None
-            budget : int [100 - 10000]
+            budget : int [500 - 10000]
                 number of epochs to train the model
             Fidelity parameters for the pyBNN model, check get_fidelity_space(). Uses default (max) value if None.
         rng : np.random.RandomState, int, None,
@@ -149,7 +149,7 @@ class BayesianNeuralNetworkBenchmark(AbstractBenchmark):
         configuration : Dict, CS.Configuration
             Configuration for the pyBNN model
         fidelity: Dict, None
-            budget : int [100 - 10000]
+            budget : int [500 - 10000]
                 number of epochs to train the model
             Fidelity parameters for the pyBNN model, check get_fidelity_space(). Uses default (max) value if None.
 
@@ -245,7 +245,7 @@ class BayesianNeuralNetworkBenchmark(AbstractBenchmark):
         Creates a ConfigSpace.ConfigurationSpace containing all fidelity parameters for pyBNN benchmark.
         Fidelities
         ----------
-        budget : int : [100, 10000]
+        budget : int : [500, 10000]
             number of epochs to train the network
 
         Parameters

--- a/hpobench/benchmarks/ml/pybnn.py
+++ b/hpobench/benchmarks/ml/pybnn.py
@@ -66,7 +66,7 @@ class BayesianNeuralNetworkBenchmark(AbstractBenchmark):
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._check_fidelity
-    def objective_function(self, configuration: Union[Dict, CS.Configuration],
+    def objective_function(self, configuration: Union[CS.Configuration, Dict],
                            fidelity: Union[Dict, CS.Configuration, None] = None,
                            rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
         """
@@ -308,36 +308,36 @@ class BNNOnToyFunction(BayesianNeuralNetworkBenchmark):
     def get_data(self):
         rng = np.random.RandomState(42)
 
-        def f(x):
+        def toy_function(x):
             eps = rng.normal() * 0.02
             y = x + 0.3 * np.sin(2 * np.pi * (x + eps)) + 0.3 * np.sin(4 * np.pi * (x + eps)) + eps
             return y
 
-        X = rng.rand(1000, 1)
-        y = np.array([f(xi) for xi in X])[:, 0]
+        data_x = rng.rand(1000, 1)
+        data_y = np.array([toy_function(xi) for xi in data_x])[:, 0]
 
-        train = X[:600]
-        train_targets = y[:600]
-        valid = X[600:800]
-        valid_targets = y[600:800]
-        test = X[800:]
-        test_targets = y[800:]
+        train = data_x[:600]
+        train_targets = data_y[:600]
+        valid = data_x[600:800]
+        valid_targets = data_y[600:800]
+        test = data_x[800:]
+        test_targets = data_y[800:]
         return train, train_targets, valid, valid_targets, test, test_targets
 
 
 class BNNOnBostonHousing(BayesianNeuralNetworkBenchmark):
     def get_data(self):
-        dm = BostonHousingData()
-        return dm.load()
+        data_manager = BostonHousingData()
+        return data_manager.load()
 
 
 class BNNOnProteinStructure(BayesianNeuralNetworkBenchmark):
     def get_data(self):
-        dm = ProteinStructureData()
-        return dm.load()
+        data_manager = ProteinStructureData()
+        return data_manager.load()
 
 
 class BNNOnYearPrediction(BayesianNeuralNetworkBenchmark):
     def get_data(self):
-        dm = YearPredictionMSDData()
-        return dm.load()
+        data_manager = YearPredictionMSDData()
+        return data_manager.load()

--- a/hpobench/benchmarks/ml/pybnn.py
+++ b/hpobench/benchmarks/ml/pybnn.py
@@ -63,9 +63,7 @@ class BayesianNeuralNetworkBenchmark(AbstractBenchmark):
     def get_data(self):
         raise NotImplementedError()
 
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
-    @AbstractBenchmark._check_fidelity
+    @AbstractBenchmark.check_parameters
     def objective_function(self, configuration: Union[CS.Configuration, Dict],
                            fidelity: Union[Dict, CS.Configuration, None] = None,
                            rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
@@ -134,9 +132,7 @@ class BayesianNeuralNetworkBenchmark(AbstractBenchmark):
                 'cost': cost,
                 'info': {'fidelity': fidelity}}
 
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
-    @AbstractBenchmark._check_fidelity
+    @AbstractBenchmark.check_parameters
     def objective_function_test(self, configuration: Union[Dict, CS.Configuration],
                                 fidelity: Union[Dict, CS.Configuration, None] = None,
                                 rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:

--- a/hpobench/benchmarks/ml/svm_benchmark.py
+++ b/hpobench/benchmarks/ml/svm_benchmark.py
@@ -92,9 +92,7 @@ class SupportVectorMachine(AbstractBenchmark):
         random_state.shuffle(self.train_idx)
 
     # pylint: disable=arguments-differ
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
-    @AbstractBenchmark._check_fidelity
+    @AbstractBenchmark.check_parameters
     def objective_function(self, configuration: Union[CS.Configuration, Dict],
                            fidelity: Union[CS.Configuration, Dict, None] = None,
                            shuffle: bool = False,
@@ -168,9 +166,7 @@ class SupportVectorMachine(AbstractBenchmark):
                          'fidelity': fidelity}}
 
     # pylint: disable=arguments-differ
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
-    @AbstractBenchmark._check_fidelity
+    @AbstractBenchmark.check_parameters
     def objective_function_test(self, configuration: Union[CS.Configuration, Dict],
                                 fidelity: Union[CS.Configuration, Dict, None] = None,
                                 shuffle: bool = False,

--- a/hpobench/benchmarks/ml/svm_benchmark.py
+++ b/hpobench/benchmarks/ml/svm_benchmark.py
@@ -72,7 +72,7 @@ class SupportVectorMachine(AbstractBenchmark):
         # (https://arxiv.org/pdf/1605.07079.pdf),
         # use 10 time the number of classes as lower bound for the dataset fraction
         n_classes = np.unique(self.y_train).shape[0]
-        self.lower_bound_train_size = int((10 * n_classes) / self.x_train.shape[0])
+        self.lower_bound_train_size = (10 * n_classes) / self.x_train.shape[0]
 
     def get_data(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, List]:
         """ Loads the data given a task or another source. """
@@ -138,8 +138,8 @@ class SupportVectorMachine(AbstractBenchmark):
         if self.lower_bound_train_size > fidelity['dataset_fraction']:
             train_size = self.lower_bound_train_size
             logger.warning(f'The given data set fraction is lower than the lower bound (10 * number of classes.) '
-                           f'Increase the fidelity from {fidelity["dataset_fraction"]:.2f} to '
-                           f'{self.lower_bound_train_size:.2f}')
+                           f'Increase the fidelity from {fidelity["dataset_fraction"]:.8f} to '
+                           f'{self.lower_bound_train_size:.8f}')
         else:
             train_size = fidelity['dataset_fraction']
 
@@ -160,9 +160,9 @@ class SupportVectorMachine(AbstractBenchmark):
 
         cost = time.time() - start_time
 
-        return {'function_value': val_loss,
+        return {'function_value': float(val_loss),
                 "cost": cost,
-                'info': {'train_loss': train_loss,
+                'info': {'train_loss': float(train_loss),
                          'fidelity': fidelity}}
 
     # pylint: disable=arguments-differ
@@ -232,9 +232,9 @@ class SupportVectorMachine(AbstractBenchmark):
 
         cost = time.time() - start_time
 
-        return {'function_value': test_loss,
+        return {'function_value': float(test_loss),
                 "cost": cost,
-                'info': {'train_valid_loss': train_valid_loss,
+                'info': {'train_valid_loss': float(train_valid_loss),
                          'fidelity': fidelity}}
 
     def get_pipeline(self, C: float, gamma: float) -> pipeline.Pipeline:

--- a/hpobench/benchmarks/ml/svm_benchmark.py
+++ b/hpobench/benchmarks/ml/svm_benchmark.py
@@ -306,8 +306,7 @@ class SupportVectorMachine(AbstractBenchmark):
         ])
         return fidel_space
 
-    @staticmethod
-    def get_meta_information():
+    def get_meta_information(self):
         """ Returns the meta information for the benchmark """
         return {'name': 'Support Vector Machine',
                 'references': ["@InProceedings{pmlr-v54-klein17a",
@@ -324,5 +323,10 @@ class SupportVectorMachine(AbstractBenchmark):
                                "publisher = {PMLR},"
                                "pdf = {http://proceedings.mlr.press/v54/klein17a/klein17a.pdf}, "
                                "url = {http://proceedings.mlr.press/v54/klein17a.html}, "
-                               ]
+                               ],
+                'shape of train data': self.X_train.shape,
+                'shape of test data': self.X_test.shape,
+                'shape of valid data': self.X_valid.shape,
+                'initial random seed': self.rng,
+                'task_id': self.task_id
                 }

--- a/hpobench/benchmarks/ml/xgboost_benchmark.py
+++ b/hpobench/benchmarks/ml/xgboost_benchmark.py
@@ -19,6 +19,7 @@ __version__ = '0.0.1'
 
 logger = logging.getLogger('XGBBenchmark')
 
+
 class XGBoostBenchmark(AbstractBenchmark):
 
     def __init__(self, task_id: Union[int, None] = None, n_threads: int = 1,

--- a/hpobench/benchmarks/ml/xgboost_benchmark.py
+++ b/hpobench/benchmarks/ml/xgboost_benchmark.py
@@ -82,9 +82,7 @@ class XGBoostBenchmark(AbstractBenchmark):
         random_state.shuffle(self.train_idx)
 
     # pylint: disable=arguments-differ
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
-    @AbstractBenchmark._check_fidelity
+    @AbstractBenchmark.check_parameters
     def objective_function(self, configuration: Union[CS.Configuration, Dict],
                            fidelity: Union[CS.Configuration, Dict, None] = None,
                            shuffle: bool = False,
@@ -142,9 +140,7 @@ class XGBoostBenchmark(AbstractBenchmark):
                 }
 
     # pylint: disable=arguments-differ
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
-    @AbstractBenchmark._check_fidelity
+    @AbstractBenchmark.check_parameters
     def objective_function_test(self, configuration: Union[CS.Configuration, Dict],
                                 fidelity: Union[CS.Configuration, Dict, None] = None,
                                 shuffle: bool = False,

--- a/hpobench/benchmarks/ml/xgboost_benchmark.py
+++ b/hpobench/benchmarks/ml/xgboost_benchmark.py
@@ -35,7 +35,7 @@ class XGBoostBenchmark(AbstractBenchmark):
         self.task_id = task_id
         self.accuracy_scorer = make_scorer(accuracy_score)
 
-        self.X_train, self.y_train, self.X_valid, self.y_valid, self.X_test, self.y_test, variable_types = \
+        self.x_train, self.y_train, self.x_valid, self.y_valid, self.x_test, self.y_test, variable_types = \
             self.get_data()
         self.categorical_data = np.array([var_type == 'categorical' for var_type in variable_types])
 
@@ -44,15 +44,15 @@ class XGBoostBenchmark(AbstractBenchmark):
         continuous_idx = np.argwhere(~self.categorical_data)
         sorting = np.concatenate([categorical_idx, continuous_idx]).squeeze()
         self.categorical_data = self.categorical_data[sorting]
-        self.X_train = self.X_train[:, sorting]
-        self.X_valid = self.X_valid[:, sorting]
-        self.X_test = self.X_test[:, sorting]
+        self.x_train = self.x_train[:, sorting]
+        self.x_valid = self.x_valid[:, sorting]
+        self.x_test = self.x_test[:, sorting]
 
-        nan_columns = np.all(np.isnan(self.X_train), axis=0)
+        nan_columns = np.all(np.isnan(self.x_train), axis=0)
         self.categorical_data = self.categorical_data[~nan_columns]
 
-        self.X_train, self.X_valid, self.X_test, self.categories = \
-            OpenMLHoldoutDataManager.replace_nans_in_cat_columns(self.X_train, self.X_valid, self.X_test,
+        self.x_train, self.x_valid, self.x_test, self.categories = \
+            OpenMLHoldoutDataManager.replace_nans_in_cat_columns(self.x_train, self.x_valid, self.x_test,
                                                                  is_categorical=self.categorical_data)
 
         # Determine the number of categories in the labels.
@@ -60,8 +60,8 @@ class XGBoostBenchmark(AbstractBenchmark):
         self.num_class = len(np.unique(np.concatenate([self.y_train, self.y_test, self.y_valid])))
         self.num_class = 1 if self.num_class == 2 else self.num_class
 
-        self.train_idx = self.rng.choice(a=np.arange(len(self.X_train)),
-                                         size=len(self.X_train),
+        self.train_idx = self.rng.choice(a=np.arange(len(self.x_train)),
+                                         size=len(self.x_train),
                                          replace=False)
 
     def get_data(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, List]:
@@ -70,10 +70,10 @@ class XGBoostBenchmark(AbstractBenchmark):
         assert self.task_id is not None, NotImplementedError('No task-id given. Please either specify a task-id or '
                                                              'overwrite the get_data method.')
 
-        dm = OpenMLHoldoutDataManager(openml_task_id=self.task_id, rng=self.rng)
-        X_train, y_train, X_val, y_val, X_test, y_test = dm.load()
+        data_manager = OpenMLHoldoutDataManager(openml_task_id=self.task_id, rng=self.rng)
+        x_train, y_train, x_val, y_val, x_test, y_test = data_manager.load()
 
-        return X_train, y_train, X_val, y_val, X_test, y_test, dm.variable_types
+        return x_train, y_train, x_val, y_val, x_test, y_test, data_manager.variable_types
 
     def shuffle_data(self, rng=None):
         """ Reshuffle the training data. If 'rng' is None, the training idx are shuffled according to the
@@ -81,11 +81,13 @@ class XGBoostBenchmark(AbstractBenchmark):
         random_state = rng_helper.get_rng(rng, self.rng)
         random_state.shuffle(self.train_idx)
 
+    # pylint: disable=arguments-differ
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._check_fidelity
-    def objective_function(self, configuration: Union[Dict, CS.Configuration],
-                           fidelity: Union[Dict, None] = None, shuffle: bool = False,
+    def objective_function(self, configuration: Union[CS.Configuration, Dict],
+                           fidelity: Union[CS.Configuration, Dict, None] = None,
+                           shuffle: bool = False,
                            rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
         """
         Trains a XGBoost model given a hyperparameter configuration and
@@ -127,10 +129,10 @@ class XGBoostBenchmark(AbstractBenchmark):
         train_idx = self.train_idx[:int(len(self.train_idx) * fidelity["dataset_fraction"])]
 
         model = self._get_pipeline(n_estimators=fidelity["n_estimators"], **configuration)
-        model.fit(X=self.X_train[train_idx], y=self.y_train[train_idx])
+        model.fit(X=self.x_train[train_idx], y=self.y_train[train_idx])
 
-        train_loss = 1 - self.accuracy_scorer(model, self.X_train[train_idx], self.y_train[train_idx])
-        val_loss = 1 - self.accuracy_scorer(model, self.X_valid, self.y_valid)
+        train_loss = 1 - self.accuracy_scorer(model, self.x_train[train_idx], self.y_train[train_idx])
+        val_loss = 1 - self.accuracy_scorer(model, self.x_valid, self.y_valid)
         cost = time.time() - start
 
         return {'function_value': val_loss,
@@ -139,12 +141,14 @@ class XGBoostBenchmark(AbstractBenchmark):
                          'fidelity': fidelity}
                 }
 
+    # pylint: disable=arguments-differ
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._check_fidelity
-    def objective_function_test(self, configuration: Union[Dict, CS.Configuration],
-                                fidelity: Union[Dict, None] = None, rng: Union[np.random.RandomState, int, None] = None,
-                                **kwargs) -> Dict:
+    def objective_function_test(self, configuration: Union[CS.Configuration, Dict],
+                                fidelity: Union[CS.Configuration, Dict, None] = None,
+                                shuffle: bool = False,
+                                rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
         """
         Trains a XGBoost model with a given configuration on both the train
         and validation data set and evaluates the model on the test data set.
@@ -155,6 +159,9 @@ class XGBoostBenchmark(AbstractBenchmark):
             Configuration for the XGBoost Model
         fidelity: Dict, None
             Fidelity parameters, check get_fidelity_space(). Uses default (max) value if None.
+        shuffle : bool
+            If ``True``, shuffle the training idx. If no parameter ``rng`` is given, use the class random state.
+            Defaults to ``False``.
         rng : np.random.RandomState, int, None,
             Random seed for benchmark. By default the class level random seed.
             To prevent overfitting on a single seed, it is possible to pass a
@@ -173,20 +180,23 @@ class XGBoostBenchmark(AbstractBenchmark):
         default_dataset_fraction = self.get_fidelity_space().get_hyperparameter('dataset_fraction').default_value
         if fidelity['dataset_fraction'] != default_dataset_fraction:
             raise NotImplementedError(f'Test error can not be computed for dataset_fraction <= '
-                                      f'{default_dataset_fraction:d}')
+                                      f'{default_dataset_fraction}')
 
         self.rng = rng_helper.get_rng(rng=rng, self_rng=self.rng)
+
+        if shuffle:
+            self.shuffle_data(self.rng)
 
         start = time.time()
 
         # Impute potential nan values with the feature-
-        data = np.concatenate((self.X_train, self.X_valid))
+        data = np.concatenate((self.x_train, self.x_valid))
         targets = np.concatenate((self.y_train, self.y_valid))
 
         model = self._get_pipeline(n_estimators=fidelity['n_estimators'], **configuration)
         model.fit(X=data, y=targets)
 
-        test_loss = 1 - self.accuracy_scorer(model, self.X_test, self.y_test)
+        test_loss = 1 - self.accuracy_scorer(model, self.x_test, self.y_test)
         cost = time.time() - start
 
         return {'function_value': test_loss,
@@ -251,9 +261,9 @@ class XGBoostBenchmark(AbstractBenchmark):
         """ Returns the meta information for the benchmark """
         return {'name': 'XGBoost',
                 'references': [],
-                'shape of train data': self.X_train.shape,
-                'shape of test data': self.X_test.shape,
-                'shape of valid data': self.X_valid.shape,
+                'shape of train data': self.x_train.shape,
+                'shape of test data': self.x_test.shape,
+                'shape of valid data': self.x_valid.shape,
                 'initial random seed': self.rng,
                 'task_id': self.task_id
                 }
@@ -266,8 +276,8 @@ class XGBoostBenchmark(AbstractBenchmark):
         clf = pipeline.Pipeline([
             ('preprocess_impute',
              ColumnTransformer([
-                ("categorical", "passthrough", self.categorical_data),
-                ("continuous", SimpleImputer(strategy="mean"), ~self.categorical_data)])),
+                 ("categorical", "passthrough", self.categorical_data),
+                 ("continuous", SimpleImputer(strategy="mean"), ~self.categorical_data)])),
             ('preprocess_one_hot',
              ColumnTransformer([
                  ("categorical", OneHotEncoder(categories=self.categories, sparse=False), self.categorical_data),
@@ -285,5 +295,5 @@ class XGBoostBenchmark(AbstractBenchmark):
                  n_jobs=self.n_threads,
                  random_state=self.rng.randint(1, 100000),
                  num_class=self.num_class))
-             ])
+            ])
         return clf

--- a/hpobench/benchmarks/ml/xgboost_benchmark.py
+++ b/hpobench/benchmarks/ml/xgboost_benchmark.py
@@ -247,11 +247,15 @@ class XGBoostBenchmark(AbstractBenchmark):
 
         return fidel_space
 
-    @staticmethod
-    def get_meta_information() -> Dict:
+    def get_meta_information(self) -> Dict:
         """ Returns the meta information for the benchmark """
         return {'name': 'XGBoost',
                 'references': [],
+                'shape of train data': self.X_train.shape,
+                'shape of test data': self.X_test.shape,
+                'shape of valid data': self.X_valid.shape,
+                'initial random seed': self.rng,
+                'task_id': self.task_id
                 }
 
     def _get_pipeline(self, eta: float, min_child_weight: int, colsample_bytree: float, colsample_bylevel: float,

--- a/hpobench/benchmarks/ml/xgboost_benchmark.py
+++ b/hpobench/benchmarks/ml/xgboost_benchmark.py
@@ -133,9 +133,9 @@ class XGBoostBenchmark(AbstractBenchmark):
         val_loss = 1 - self.accuracy_scorer(model, self.x_valid, self.y_valid)
         cost = time.time() - start
 
-        return {'function_value': val_loss,
+        return {'function_value': float(val_loss),
                 'cost': cost,
-                'info': {'train_loss': train_loss,
+                'info': {'train_loss': float(train_loss),
                          'fidelity': fidelity}
                 }
 

--- a/hpobench/benchmarks/nas/nasbench_101.py
+++ b/hpobench/benchmarks/nas/nasbench_101.py
@@ -157,10 +157,11 @@ class NASCifar10BaseBenchmark(AbstractBenchmark):
         valid_accuracies = []
         test_accuracies = []
         training_times = []
-        additional = []
+        additional = {}
 
         for run_id in run_index:
             data = self._query_benchmark(config=configuration, budget=fidelity['budget'], run_index=run_id)
+
             train_accuracies.append(data['train_accuracy'])
             valid_accuracies.append(data['validation_accuracy'])
             test_accuracies.append(data['test_accuracy'])
@@ -305,6 +306,8 @@ class NASCifar10ABenchmark(NASCifar10BaseBenchmark):
         Parameters
         ----------
         config : Dict
+        run_index : int
+            Specifies the seed to use. Can be one of 0, 1, 2.
         budget : int
             The number of epochs. Must be one of: 4 12 36 108. Otherwise a accuracy of 0 is returned.
 
@@ -334,6 +337,7 @@ class NASCifar10ABenchmark(NASCifar10BaseBenchmark):
         labeling = [config["op_node_%d" % i] for i in range(5)]
         labeling = ['input'] + list(labeling) + ['output']
         model_spec = api.ModelSpec(matrix, labeling)
+
         try:
             data = modified_query(self.benchmark, run_index=run_index, model_spec=model_spec, epochs=budget)
         except api.OutOfDomainError:
@@ -416,7 +420,7 @@ class NASCifar10BBenchmark(NASCifar10BaseBenchmark):
         labeling = ['input'] + list(labeling) + ['output']
         model_spec = api.ModelSpec(matrix, labeling)
         try:
-            data = self.benchmark.dataset.query(model_spec, epochs=budget)
+            data = modified_query(self.benchmark, run_index=run_index, model_spec=model_spec, epochs=budget)
         except api.OutOfDomainError:
             self.benchmark.record_invalid(config, 1, 1, 0)
             return failure
@@ -501,7 +505,7 @@ class NASCifar10CBenchmark(NASCifar10BaseBenchmark):
         labeling = ['input'] + list(labeling) + ['output']
         model_spec = api.ModelSpec(matrix, labeling)
         try:
-            data = self.benchmark.dataset.query(model_spec, epochs=budget)
+            data = modified_query(self.benchmark, run_index=run_index, model_spec=model_spec, epochs=budget)
         except api.OutOfDomainError:
             self.benchmark.record_invalid(config, 1, 1, 0)
             return failure

--- a/hpobench/benchmarks/nas/nasbench_101.py
+++ b/hpobench/benchmarks/nas/nasbench_101.py
@@ -92,6 +92,7 @@ class NASCifar10BaseBenchmark(AbstractBenchmark):
     def _query_benchmark(self, config: Dict, run_index: int, budget: int = 108) -> Dict:
         raise NotImplementedError
 
+    # pylint: disable=arguments-differ
     @AbstractBenchmark.check_parameters
     def objective_function(self, configuration: Union[CS.Configuration, Dict],
                            fidelity: Union[CS.Configuration, Dict, None] = None,

--- a/hpobench/benchmarks/nas/nasbench_101.py
+++ b/hpobench/benchmarks/nas/nasbench_101.py
@@ -92,9 +92,7 @@ class NASCifar10BaseBenchmark(AbstractBenchmark):
     def _query_benchmark(self, config: Dict, run_index: int, budget: int = 108) -> Dict:
         raise NotImplementedError
 
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
-    @AbstractBenchmark._check_fidelity
+    @AbstractBenchmark.check_parameters
     def objective_function(self, configuration: Union[CS.Configuration, Dict],
                            fidelity: Union[CS.Configuration, Dict, None] = None,
                            run_index: Union[int, Tuple, None] = (0, 1, 2),
@@ -182,9 +180,7 @@ class NASCifar10BaseBenchmark(AbstractBenchmark):
                          }
                 }
 
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
-    @AbstractBenchmark._check_fidelity
+    @AbstractBenchmark.check_parameters
     def objective_function_test(self, configuration: Union[Dict, CS.Configuration],
                                 fidelity: Union[CS.Configuration, Dict, None] = None,
                                 rng: Union[np.random.RandomState, int, None] = None,

--- a/hpobench/benchmarks/nas/nasbench_1shot1.py
+++ b/hpobench/benchmarks/nas/nasbench_1shot1.py
@@ -41,17 +41,20 @@ git clone https://github.com/automl/nasbench-1shot1/tree/master/nasbench_analysi
 
 To use the nasbench_analysis package, add the path to this folder to your PATH variable.
 ```
-export PATH=/Path/to/nasbench-1shot1-directory:$PATH
+export PATH=/Path/to/nasbench-1shot1:$PATH
 ```
 """
+import logging
 
 from pathlib import Path
-from typing import Union, Dict, Any
+from typing import Union, Dict, Any, Tuple, List
 from ast import literal_eval
 
 import ConfigSpace as CS
 import numpy as np
 from nasbench import api
+from nasbench.api import OutOfDomainError
+
 from hpobench.abstract_benchmark import AbstractBenchmark
 from hpobench.util.data_manager import NASBench_101DataManager
 from hpobench.util import rng_helper
@@ -61,7 +64,8 @@ from nasbench_analysis.search_spaces.search_space_2 import SearchSpace2  # noqa
 from nasbench_analysis.search_spaces.search_space_3 import SearchSpace3  # noqa
 from nasbench_analysis.utils import INPUT, OUTPUT, CONV1X1, CONV3X3, MAXPOOL3X3  # noqa
 
-__version__ = '0.0.1'
+__version__ = '0.0.2'
+logger = logging.getLogger('NasBench1shot1')
 
 
 class NASBench1shot1BaseBenchmark(AbstractBenchmark):
@@ -83,54 +87,16 @@ class NASBench1shot1BaseBenchmark(AbstractBenchmark):
         self.api = data_manager.load()
         self.search_space = None
 
-    def _query_benchmark(self, config: Dict, fidelity: Dict) -> Dict:
-        adjacency_matrix, node_list = self.search_space.convert_config_to_nasbench_format(config)
-        node_list = [INPUT, *node_list, CONV1X1, OUTPUT]
-        adjacency_list = adjacency_matrix.astype(np.int).tolist()
-        model_spec = api.ModelSpec(matrix=adjacency_list, ops=node_list)
-        nasbench_data = self.api.query(model_spec, epochs=int(fidelity['budget']))
-
-        info = {'trainable_parameters': nasbench_data['trainable_parameters'],
-                'training_time': nasbench_data['training_time'],
-                'train_accuracy': nasbench_data['train_accuracy'],
-                'validation_accuracy': nasbench_data['validation_accuracy'],
-                'test_accuracy': nasbench_data['test_accuracy'],
-                'fidelity': fidelity}
-
-        return info
-
-    def _parse_configuration(self, configuration: Dict):
-        """
-        Since the categorical hyperparameters are stored as strings (otherwise they are not json serializable),
-        we need to cast them back to tuple.
-
-        In the original configuration space all hyperparameters are of either of type string or tuple.
-        In the modified, also the tuple hp are strings. A tuple hyperparameter is indicated here by a opening bracket.
-
-        Parameters
-        ----------
-        configuration : Dict.
-
-        Returns
-        -------
-        Dict - configuration with the correct types
-        """
-        # make sure that it is a dictionary and not a CS.Configuration.
-        if isinstance(configuration, CS.Configuration):
-            configuration = configuration.get_dictionary()
-
-        return {k: literal_eval(v) if isinstance(v, str) and v[0] == '(' else v
-                for k, v in configuration.items()}
-
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._check_fidelity
     def objective_function(self, configuration: Union[CS.Configuration, Dict],
                            fidelity: Union[CS.Configuration, Dict, None] = None,
+                           run_index: Union[int, Tuple, List, None] = (0, 1, 2),
                            rng: Union[np.random.RandomState, int, None] = None,
                            **kwargs) -> Dict:
         """
-        Query the NAS-benchmark using a given configuration and a epoch (=budget).
+        Query the NAS1shot1-benchmark using a given configuration and an epoch (=budget).
         Only data for the budgets 4, 12, 36, 108 are available.
 
         Parameters
@@ -138,6 +104,13 @@ class NASBench1shot1BaseBenchmark(AbstractBenchmark):
         configuration : Dict, CS.Configuration
         fidelity: Dict, None
             Fidelity parameters, check get_fidelity_space(). Uses default (max) value if None.
+        run_index : int, Tuple, None
+            The nas benchmark has for each configuration-budget-pair results from 3 different runs.
+            - If multiple `run_id`s are given as Tuple/List, the benchmark returns the mean over the given runs.
+            - By default (no parameter is specified) all runs are used. A specific run can be chosen by setting the
+              `run_id` to a value from [0, 3]. While the performance is averaged across the `run_index`, the costs are
+              the sum of the runtime per `run_index`.
+            - When this value is explicitly set to `None`, the function will use a random seed.
         rng : np.random.RandomState, int, None
             Random seed to use in the benchmark.
 
@@ -152,22 +125,47 @@ class NASBench1shot1BaseBenchmark(AbstractBenchmark):
             function_value : validation error
             cost : runtime
             info : Dict
-                trainable_parameters:
-                training_time
-                train_accuracy
-                validation_accuracy
-                test_accuracy
+                train_accuracies
+                test_accuracies
+                valid_accuracies
+                training_times
                 fidelity : used fidelities in this evaluation
+                data : additional data such as trainable parameters and used operations
         """
         self.rng = rng_helper.get_rng(rng, self_rng=self.rng)
 
+        run_index = self._check_run_index(run_index)
         configuration = self._parse_configuration(configuration)
 
-        info = self._query_benchmark(configuration, fidelity)
+        train_accuracies = []
+        valid_accuracies = []
+        test_accuracies = []
+        training_times = []
+        additional = {}
+        failure = False
+        for run_id in run_index:
+            data = self._query_benchmark(config=configuration, fidelity=fidelity, run_index=run_id)
+            train_accuracies.append(data['train_accuracy'])
+            valid_accuracies.append(data['validation_accuracy'])
+            test_accuracies.append(data['test_accuracy'])
+            training_times.append(data['training_time'])
 
-        return {'function_value': 1 - info['validation_accuracy'],
-                'cost': info['training_time'],
-                'info': info}
+            # Since those information are the same for all run ids, just store one of them.
+            additional = {'trainable_parameters': data['trainable_parameters'],
+                          'module_operations': data['module_operations']}
+            failure = failure or ('info' in data and data['info'] == 'failure')
+
+        return {'function_value': float(1 - np.mean(valid_accuracies)),
+                'cost': float(np.sum(training_times)),
+                'info': {'fidelity': fidelity,
+                         'train_accuracies': train_accuracies,
+                         'valid_accuracies': valid_accuracies,
+                         'test_accuracies': test_accuracies,
+                         'training_times': training_times,
+                         'data': additional,
+                         'failure': 'False' if not failure else 'True'
+                         }
+                }
 
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
@@ -177,7 +175,7 @@ class NASBench1shot1BaseBenchmark(AbstractBenchmark):
                                 rng: Union[np.random.RandomState, int, None] = None,
                                 **kwargs) -> Dict:
         """
-        Validate a configuration on the maximum available budget (108).
+        Validate a configuration on the maximum available budget (108) and on all three seeds.
 
         Parameters
         ----------
@@ -193,68 +191,24 @@ class NASBench1shot1BaseBenchmark(AbstractBenchmark):
         Returns
         -------
         Dict -
-            function_value : test error
+            function_value : test error on largest fidelity.
             cost : runtime
             info : Dict
-                trainable_parameters:
-                training_time
-                train_accuracy
-                validation_accuracy
-                test_accuracy
+                train_accuracies
+                test_accuracies
+                valid_accuracies
+                training_times
                 fidelity : used fidelities in this evaluation
+                data : additional data such as trainable parameters and used operations
         """
-        self.rng = rng_helper.get_rng(rng, self_rng=self.rng)
-
-        assert fidelity['budget'] == 108, 'Only test data for the 108th epoch is available. '
-
-        configuration = self._parse_configuration(configuration)
-        info = self._query_benchmark(configuration, fidelity)
-
-        return {'function_value': 1 - info['test_accuracy'],
-                'cost': info['training_time'],
-                'info': info}
+        assert fidelity['budget'] == 108, 'Only test data for the 108th epoch is available.'
+        result = self.objective_function(configuration=configuration, fidelity=fidelity, run_index=(0, 1, 2), rng=rng)
+        result['function_value'] = float(1 - np.mean(result['info']['test_accuracies']))
+        return result
 
     @staticmethod
     def get_configuration_space(seed: Union[int, None] = None) -> CS.ConfigurationSpace:
         raise NotImplementedError
-
-    @staticmethod
-    def get_meta_information() -> Dict:
-        """ Returns the meta information for the benchmark """
-        return {'name': '',
-                'references': ['Arber Zela and Julien Siems and Frank Hutter',
-                               'NAS-Bench-1Shot1: Benchmarking and Dissecting One-shot Neural Architecture Search',
-                               '@inproceedings{Zela2020NAS-Bench-1Shot1:, '
-                               'title={NAS-Bench-1Shot1: '
-                               '       Benchmarking and Dissecting One-shot Neural Architecture Search},'
-                               'author={Arber Zela and Julien Siems and Frank Hutter},'
-                               'booktitle={International Conference on Learning Representations},'
-                               'year={2020},'
-                               'url={https://openreview.net/forum?id=SJx9ngStPH}}'
-                               'https://github.com/automl/nasbench-1shot1'],
-                }
-
-    @staticmethod
-    def _get_configuration_space(search_space: Any, seed: Union[int, None] = None) -> CS.ConfigurationSpace:
-        """ Helper function to pass a seed to the configuration space """
-        seed = seed if seed is not None else np.random.randint(1, 100000)
-        original_cs = search_space.get_configuration_space()
-
-        # The categorical hyperparameter of this benchmark consist of some tuple(tuple(int, int)). This is not by
-        # json serializable with the configspace. Therefore, we cast it to a string.
-        hps = []
-        for hp in original_cs.get_hyperparameters():
-            # the configspaces of this benchmark have only categorical hp
-            # --> so they will all have the attribute 'default value'
-            if isinstance(hp.default_value, tuple):
-                hp = CS.CategoricalHyperparameter(hp.name,
-                                                  choices=[str(choice) for choice in hp.choices],
-                                                  default_value=str(hp.default_value))
-            hps.append(hp)
-        cs = CS.ConfigurationSpace()
-        cs.add_hyperparameters(hps)
-        cs.seed(seed)
-        return cs
 
     @staticmethod
     def get_fidelity_space(seed: Union[int, None] = None) -> CS.ConfigurationSpace:
@@ -279,6 +233,179 @@ class NASBench1shot1BaseBenchmark(AbstractBenchmark):
         ])
 
         return fidel_space
+
+    @staticmethod
+    def get_meta_information() -> Dict:
+        """ Returns the meta information for the benchmark """
+        return {'name': '',
+                'references': ['Arber Zela and Julien Siems and Frank Hutter',
+                               'NAS-Bench-1Shot1: Benchmarking and Dissecting One-shot Neural Architecture Search',
+                               '@inproceedings{Zela2020NAS-Bench-1Shot1:, '
+                               'title={NAS-Bench-1Shot1: '
+                               '       Benchmarking and Dissecting One-shot Neural Architecture Search},'
+                               'author={Arber Zela and Julien Siems and Frank Hutter},'
+                               'booktitle={International Conference on Learning Representations},'
+                               'year={2020},'
+                               'url={https://openreview.net/forum?id=SJx9ngStPH}}'
+                               'https://github.com/automl/nasbench-1shot1'],
+                }
+
+    def _check_run_index(self, run_index):
+
+        if isinstance(run_index, int):
+            assert 0 <= run_index <= 2, f'run_index must be in [0, 2], not {run_index}'
+            run_index = (run_index, )
+        elif isinstance(run_index, (Tuple, List)):
+            assert 0 < len(run_index) <= 3, 'run_index must not be empty'
+            assert min(run_index) >= 0 and max(run_index) <= 2, \
+                f'all run_index values must be in [0, 2], but were {run_index}'
+            if len(set(run_index)) != len(run_index):
+                logger.debug('There are some values more than once in the run_index. We remove the redundant entries.')
+                run_index = tuple(set(run_index))
+        elif run_index is None:
+            logger.debug('The run index is explicitly set to None! A random seed will be selected.')
+            run_index = tuple(self.rng.choice((0, 1, 2), size=1))
+        else:
+            raise ValueError(f'run index must be one of Tuple or Int, but was {type(run_index)}')
+
+        return run_index
+
+    def _query_benchmark(self, config: Dict, fidelity: Dict, run_index: int) -> Dict:
+
+        adjacency_matrix, node_list = self.search_space.convert_config_to_nasbench_format(config)
+        node_list = [INPUT, *node_list, CONV1X1, OUTPUT]
+        adjacency_list = adjacency_matrix.astype(np.int).tolist()
+        model_spec = api.ModelSpec(matrix=adjacency_list, ops=node_list)
+
+        try:
+            nasbench_data = self._query_api(model_spec=model_spec, run_index=run_index, epochs=int(fidelity['budget']))
+        except api.OutOfDomainError:
+            return {"trainable_parameters": 0,
+                    "training_time": 0,
+                    "train_accuracy": 0,
+                    "validation_accuracy": 0,
+                    "test_accuracy": 0,
+                    "module_operations": 0,
+                    "info": "failure"}
+
+        nasbench_data.pop('module_adjacency')
+        return nasbench_data
+
+    def _query_api(self, model_spec, run_index: int, epochs=108, stop_halfway=False):
+        """
+        NOTE:
+        Copied from https://github.com/google-research/nasbench/blob/b94247037ee470418a3e56dcb83814e9be83f3a8/nasbench/api.py#L204-L263  # noqa
+        We changed the function in such a way that we now can specified the run index (index of the evaluation) which was
+        in the original code sampled randomly.
+
+        OLD DOCSTRING:
+        Fetch one of the evaluations for this model spec.
+
+        Each call will sample one of the config['num_repeats'] evaluations of the
+        model. This means that repeated queries of the same model (or isomorphic
+        models) may return identical metrics.
+
+        This function will increment the budget counters for benchmarking purposes.
+        See self.training_time_spent, and self.total_epochs_spent.
+
+        This function also allows querying the evaluation metrics at the halfway
+        point of training using stop_halfway. Using this option will increment the
+        budget counters only up to the halfway point.
+
+        Args:
+          model_spec: ModelSpec object.
+          epochs: number of epochs trained. Must be one of the evaluated number of
+            epochs, [4, 12, 36, 108] for the full dataset.
+          stop_halfway: if True, returned dict will only contain the training time
+            and accuracies at the halfway point of training (num_epochs/2).
+            Otherwise, returns the time and accuracies at the end of training
+            (num_epochs).
+
+        Returns:
+          dict containing the evaluated data for this object.
+
+        Raises:
+          OutOfDomainError: if model_spec or num_epochs is outside the search space.
+        """
+        if epochs not in self.api.valid_epochs:
+            raise OutOfDomainError('invalid number of epochs, must be one of %s'
+                                   % self.api.valid_epochs)
+
+        fixed_stat, computed_stat = self.api.get_metrics_from_spec(model_spec)
+
+        # MODIFICATION: Use the run index instead of the sampled one.
+        # ORIGINAL CODE:
+        # sampled_index = random.randint(0, self.config['num_repeats'] - 1)
+        computed_stat = computed_stat[epochs][run_index]
+
+        data = {}
+        data['module_adjacency'] = fixed_stat['module_adjacency']
+        data['module_operations'] = fixed_stat['module_operations']
+        data['trainable_parameters'] = fixed_stat['trainable_parameters']
+
+        if stop_halfway:
+            data['training_time'] = computed_stat['halfway_training_time']
+            data['train_accuracy'] = computed_stat['halfway_train_accuracy']
+            data['validation_accuracy'] = computed_stat['halfway_validation_accuracy']
+            data['test_accuracy'] = computed_stat['halfway_test_accuracy']
+        else:
+            data['training_time'] = computed_stat['final_training_time']
+            data['train_accuracy'] = computed_stat['final_train_accuracy']
+            data['validation_accuracy'] = computed_stat['final_validation_accuracy']
+            data['test_accuracy'] = computed_stat['final_test_accuracy']
+
+        self.api.training_time_spent += data['training_time']
+        if stop_halfway:
+            self.api.total_epochs_spent += epochs // 2
+        else:
+            self.api.total_epochs_spent += epochs
+
+        return data
+
+    def _parse_configuration(self, configuration: Dict):
+        """
+        Since the categorical hyperparameters are stored as strings (otherwise they would not be json serializable),
+        we need to cast them back to type tuple.
+
+        In the original configuration space all hyperparameters are either of type string or tuple.
+        In the modified configuration space, the tuple hp are also strings.
+
+        Parameters
+        ----------
+        configuration : Dict.
+
+        Returns
+        -------
+        Dict - configuration with the correct types
+        """
+        # make sure that it is a dictionary and not a CS.Configuration.
+        if isinstance(configuration, CS.Configuration):
+            configuration = configuration.get_dictionary()
+
+        return {k: literal_eval(v) if isinstance(v, str) and v[0] == '(' else v
+                for k, v in configuration.items()}
+
+    @staticmethod
+    def _get_configuration_space(search_space: Any, seed: Union[int, None] = None) -> CS.ConfigurationSpace:
+        """ Helper function to pass a seed to the configuration space """
+        seed = seed if seed is not None else np.random.randint(1, 100000)
+        original_cs = search_space.get_configuration_space()
+
+        # The categorical hyperparameter of this benchmark consist of some tuple(tuple(int, int)). This is not
+        # json serializable with the configspace serializer. Therefore, we cast it to a string.
+        hps = []
+        for hp in original_cs.get_hyperparameters():
+            # the configspaces of this benchmark have only categorical hp
+            # --> so they will all have the attribute 'default value'
+            if isinstance(hp.default_value, tuple):
+                hp = CS.CategoricalHyperparameter(hp.name,
+                                                  choices=[str(choice) for choice in hp.choices],
+                                                  default_value=str(hp.default_value))
+            hps.append(hp)
+        cs = CS.ConfigurationSpace()
+        cs.add_hyperparameters(hps)
+        cs.seed(seed)
+        return cs
 
 
 class NASBench1shot1SearchSpace1Benchmark(NASBench1shot1BaseBenchmark):

--- a/hpobench/benchmarks/nas/nasbench_1shot1.py
+++ b/hpobench/benchmarks/nas/nasbench_1shot1.py
@@ -87,9 +87,7 @@ class NASBench1shot1BaseBenchmark(AbstractBenchmark):
         self.api = data_manager.load()
         self.search_space = None
 
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
-    @AbstractBenchmark._check_fidelity
+    @AbstractBenchmark.check_parameters
     def objective_function(self, configuration: Union[CS.Configuration, Dict],
                            fidelity: Union[CS.Configuration, Dict, None] = None,
                            run_index: Union[int, Tuple, List, None] = (0, 1, 2),
@@ -167,9 +165,7 @@ class NASBench1shot1BaseBenchmark(AbstractBenchmark):
                          }
                 }
 
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
-    @AbstractBenchmark._check_fidelity
+    @AbstractBenchmark.check_parameters
     def objective_function_test(self, configuration: Union[Dict, CS.Configuration],
                                 fidelity: Union[CS.Configuration, Dict, None] = None,
                                 rng: Union[np.random.RandomState, int, None] = None,

--- a/hpobench/benchmarks/nas/nasbench_1shot1.py
+++ b/hpobench/benchmarks/nas/nasbench_1shot1.py
@@ -87,6 +87,7 @@ class NASBench1shot1BaseBenchmark(AbstractBenchmark):
         self.api = data_manager.load()
         self.search_space = None
 
+    # pylint: disable=arguments-differ
     @AbstractBenchmark.check_parameters
     def objective_function(self, configuration: Union[CS.Configuration, Dict],
                            fidelity: Union[CS.Configuration, Dict, None] = None,

--- a/hpobench/benchmarks/nas/nasbench_201.py
+++ b/hpobench/benchmarks/nas/nasbench_201.py
@@ -138,11 +138,12 @@ class NasBench201BaseBenchmark(AbstractBenchmark):
                    'cifar100': ('ori-test', 'x-test')}
         return mapping[dataset]
 
+    # pylint: disable=arguments-differ
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._check_fidelity
     def objective_function(self, configuration: Union[CS.Configuration, Dict],
-                           fidelity: Union[Dict, None] = None,
+                           fidelity: Union[Dict, CS.Configuration, None] = None,
                            rng: Union[np.random.RandomState, int, None] = None,
                            data_seed: Union[List, Tuple, int, None] = (777, 888, 999),
                            **kwargs) -> Dict:
@@ -318,8 +319,10 @@ class NasBench201BaseBenchmark(AbstractBenchmark):
 
     @staticmethod
     def config_to_structure_func(max_nodes: int):
-        # From https://github.com/D-X-Y/AutoDL-Projects/blob/master/exps/algos/BOHB.py
-        # Author: https://github.com/D-X-Y [Xuanyi.Dong@student.uts.edu.au]
+        """
+        From https://github.com/D-X-Y/AutoDL-Projects/blob/master/exps/algos/BOHB.py
+        Author: https://github.com/D-X-Y [Xuanyi.Dong@student.uts.edu.au]
+        """
         def config_to_structure(config):
             genotypes = []
             for i in range(1, max_nodes):
@@ -334,9 +337,11 @@ class NasBench201BaseBenchmark(AbstractBenchmark):
 
     @staticmethod
     def get_search_spaces(xtype: str, name: str) -> List[Text]:
-        # obtain the search space, i.e., a dict mapping the operation name into a python-function for this op
-        # From https://github.com/D-X-Y/AutoDL-Projects/blob/master/lib/models/__init__.py
-        # Author: https://github.com/D-X-Y [Xuanyi.Dong@student.uts.edu.au]
+        """ obtain the search space, i.e., a dict mapping the operation name into a python-function for this op
+        From https://github.com/D-X-Y/AutoDL-Projects/blob/master/lib/models/__init__.py
+        Author: https://github.com/D-X-Y [Xuanyi.Dong@student.uts.edu.au]
+        """
+        # pylint: disable=no-else-return
         if xtype == 'cell':
             NAS_BENCH_201 = ['none', 'skip_connect', 'nor_conv_1x1', 'nor_conv_3x3', 'avg_pool_3x3']
             SearchSpaceNames = {'nas-bench-201': NAS_BENCH_201}
@@ -410,25 +415,21 @@ class NasBench201BaseBenchmark(AbstractBenchmark):
 
     class _Structure:
         def __init__(self, genotype):
-            assert isinstance(genotype, list) or isinstance(genotype, tuple), 'invalid class of genotype : {:}'.format(
-                type(genotype))
+            assert isinstance(genotype, (list, tuple)), 'invalid class of genotype : {:}'.format(type(genotype))
             self.node_num = len(genotype) + 1
             self.nodes = []
             self.node_N = []
             for idx, node_info in enumerate(genotype):
-                assert isinstance(node_info, list) or isinstance(node_info,
-                                                                 tuple), 'invalid class of node_info : {:}'.format(
-                    type(node_info))
+                assert isinstance(node_info, (list, tuple)), 'invalid class of node_info : {:}'.format(type(node_info))
                 assert len(node_info) >= 1, 'invalid length : {:}'.format(len(node_info))
                 for node_in in node_info:
-                    assert isinstance(node_in, list) or isinstance(node_in,
-                                                                   tuple), 'invalid class of in-node : {:}'.format(
-                        type(node_in))
+                    assert isinstance(node_in, (list, tuple)), 'invalid class of in-node : {:}'.format(type(node_in))
                     assert len(node_in) == 2 and node_in[1] <= idx, 'invalid in-node : {:}'.format(node_in)
                 self.node_N.append(len(node_info))
                 self.nodes.append(tuple(deepcopy(node_info)))
 
         def tostr(self):
+            """ Helper function: Create a string representation of the configuration """
             strings = []
             for node_info in self.nodes:
                 string = '|'.join([x[0] + '~{:}'.format(x[1]) for x in node_info])

--- a/hpobench/benchmarks/nas/nasbench_201.py
+++ b/hpobench/benchmarks/nas/nasbench_201.py
@@ -139,9 +139,7 @@ class NasBench201BaseBenchmark(AbstractBenchmark):
         return mapping[dataset]
 
     # pylint: disable=arguments-differ
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
-    @AbstractBenchmark._check_fidelity
+    @AbstractBenchmark.check_parameters
     def objective_function(self, configuration: Union[CS.Configuration, Dict],
                            fidelity: Union[Dict, CS.Configuration, None] = None,
                            rng: Union[np.random.RandomState, int, None] = None,
@@ -260,9 +258,7 @@ class NasBench201BaseBenchmark(AbstractBenchmark):
                          }
                 }
 
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
-    @AbstractBenchmark._check_fidelity
+    @AbstractBenchmark.check_parameters
     def objective_function_test(self, configuration: Union[CS.Configuration, Dict],
                                 fidelity: Union[Dict, None] = None,
                                 rng: Union[np.random.RandomState, int, None] = None,

--- a/hpobench/benchmarks/nas/nasbench_201.py
+++ b/hpobench/benchmarks/nas/nasbench_201.py
@@ -60,54 +60,61 @@ class NasBench201BaseBenchmark(AbstractBenchmark):
         'train_acc1es', 'train_losses', 'train_times', 'eval_acc1es', 'eval_times', 'eval_losses' are available.
         However, the data sets report them on different data splits (train, train + valid, test, valid or test+valid).
 
+        We summarize all information about the data sets in the following tables.
+
+        Datastet        Metric      Avail.Epochs    Explanation             returned by HPOBENCH
+        ----------------------------------------------------------------------------------------
+        cifar10-valid   train       [0-199]         training set
+        cifar10-valid   x-valid     [0-199]         validation set          objective function
+        cifar10-valid   x-test
+        cifar10-valid   ori-test    199             test set                objective function test
+
+        cifar100        train       [0-199]         training set
+        cifar100        x-valid     199             validation set
+        cifar100        x-test      199             test set                objective function test
+        cifar100        ori-test    [0-199]         validation + test set   objective function
+
+        ImageNet16-120  train       [0-199]         training set
+        ImageNet16-120  x-valid     199             validation set
+        ImageNet16-120  x-test      199             test set                objective function test
+        ImageNet16-120  ori-test    [0-199]         validation + test set   objective function
+
+
+        We have also extracted the incumbents per split. We report the incumbent accuracy and loss performance
+        i) by taking the maximum value across all seeds and configurations
+        ii) averaged across the three available seeds
+
+                                    i) The best possible incumbents (NO AVG!)                       ii) The "average" incumbent
+        Datastet        Metric      (Index of Arch, Accuracy)       (Index, Loss)                   (Index of Arch, Accuracy)       (Index, Loss)
+        ----------------------------------------------------------------------------------------------------------------------------------------------------------
+        cifar10-valid   train       (258, 100.0)                    (2778, 0.001179278278425336)    (10154, 100)                    (2778, 0.0013082386429297428)
+        cifar10-valid   x-valid     (6111, 91.71999999023437)       (14443, 0.3837750501537323)     (6111, 91.60666665039064)       (3888, 0.3894046771335602)
+        cifar10-valid   x-test
+        cifar10-valid   ori-test    (14174, 91.65)                  (3385, 0.3850496160507202)      (1459, 91.52333333333333)       (3385, 0.3995230517864227)
+
+        cifar100        train       (9930, 99.948)                  (9930, 0.012630240231156348)    (9930, 99.93733333333334)       (9930, 0.012843489621082942)
+        cifar100        x-valid     (13714, 73.71999998779297)      (13934, 1.1490126512527465)     (9930, 73.4933333577474)        (7361, 1.1600867895126343)
+        cifar100        x-test      (1459, 74.28000004882813)       (15383, 1.1427113876342774)     (9930, 73.51333332112631)       (7337, 1.1747569534301758)
+        cifar100        ori-test    (9930, 73.88)                   (13706, 1.1610547459602356)     (9930, 73.50333333333333)       (7361, 1.1696554500579834)
+
+        ImageNet16-120  train       (9930, 73.2524719841793)        (9930, 0.9490517352046979)      (9930, 73.22918040138735)       (9930, 0.9524298415108582)
+        ImageNet16-120  x-valid     (13778, 47.39999985758463)      (10721, 2.0826991437276203)     (10676, 46.73333327229818)      (10721, 2.0915397168795264)
+        ImageNet16-120  x-test      (857, 48.03333317057292)        (12887, 2.0940088628133138)     (857, 47.31111100599501)        (11882, 2.106453532218933)
+        ImageNet16-120  ori-test    (857, 47.083333353678384)       (11882, 2.0950548852284747)     (857, 46.8444444647895)         (11882, 2.1028235816955565)
+
+
         Note:
         - The parameter epoch is 0 indexed!
         - In the original data, the training splits are always marked with the key 'train' but they use different
           identifiers to refer to the available evaluation splits. We report them also in the table below.
+        - We exclude the data set cifar10 from this benchmark.
 
-        The table in the following shows the mapping from data set and metric to used split.
-
-        |-------------------|---------------|-----------------------------------|
-        | Data set          | train_*       | eval_*        (key in orig. data) |
-        |-------------------|---------------|-----------------------------------|
-        | 'cifar10-valid'   | train         | valid         (x-valid)           |
-        | 'cifar10'         | train + valid | test          (ori-test)          |
-        | 'cifar100'        | train         | valid + test  (ori-test)          |
-        | 'ImageNet16-120'  | train         | valid + test  (ori-test)          |
-        |-------------------|---------------|-----------------------------------|
-
-
-        Some further remarks:
+         Some further remarks:
         - cifar10-valid is trained on the train split and tested on the validation split.
-        - cifar10 is trained on the train *and* validation split and tested on the test split.
         - The train metrics are dictionaries with epochs (e.g. 0, 1, 2) as key and the metric as value.
           The evaluation metrics, however, have as key the identifiers, e.g. ori-test@0, with 0 indicating the epoch.
-          Also, each data set (except for cifar10) reports values for all 200 epochs for a metric on the specified
-          split (see first table) and a single value on the 200th epoch for the other splits.
-          Table 3 shows the available identifiers for each data set.
-
-        |-------------------|------------------------------|
-        | Data set          | eval*:   values for epochs   |
-        |-------------------|------------------------------|
-        | 'cifar10-valid'   | x-valid:	0-199	           |
-        |		     		| ori-test:	199		           |
-        | 'cifar10'         | ori-test:	0-199	           |
-        | 'cifar100'        | ori-test:	0-199	           |
-        |					| x-valid:	199		           |
-        |   				| x-test:   199                |
-        | 'ImageNet16-120'  | ori-test:	0-199	           |
-        |					| x-valid:	199		           |
-        |   				| x-test:  	199                |
-        |-------------------|------------------------------|
-
-        Incumbents per dataset:
-
-        Dataset             Metric      Explanation                     (Index of Arch, Accuracy)
-        -----------------------------------------------------------------------------------------
-        cifar10-valid       ori-test    (test set)                      (1459, 91.52333333333333)
-        cifar10             ori-test    (test set)                      (6111, 94.37333333333333)
-        cifar100            x-test      (test set)                      (9930, 73.51333332112631)
-        ImageNet16-120      x-test      (test set)                      (857, 47.31111100599501)
+          Also, each data set reports values for all 200 epochs for a metric on the specified split
+          and a single value on the 200th epoch for the other splits.
 
         Parameters
         ----------
@@ -115,7 +122,7 @@ class NasBench201BaseBenchmark(AbstractBenchmark):
             One of cifar10-valid, cifar10, cifar100, ImageNet16-120.
         rng : np.random.RandomState, int, None
             Random seed for the benchmark's random state.
-        """
+        """  # noqa: E501
 
         super(NasBench201BaseBenchmark, self).__init__(rng=rng)
 
@@ -142,26 +149,10 @@ class NasBench201BaseBenchmark(AbstractBenchmark):
         """
         Objective function for the NASBench201 benchmark.
         This functions sends a query to NASBench201 and evaluates the configuration.
-        As already explained in the class definition, different data sets are trained on different splits. For example
-        cifar10 is trained on the train and validation split and tested on the test split. Therefore, different entries
-        are returned from the NASBench201 result.
+        As already explained in the class definition, different data sets are trained on different splits.
 
-        Overview of the used splits for training and testing and which are returned in the objective_function and
-        which in the objective_function_test.
-
-        |-------------------|-----------------------|---------------------------|
-        |                   | Returned by           | Returned by               |
-        |                   |   objective_function  |   objective_function_test |
-        | Data set          | train_*               | eval_*                    |
-        |-------------------|-----------------------|---------------------------|
-        | 'cifar10-valid'   | train                 | valid                     |
-        | 'cifar10'         | train + valid         | test                      |
-        | 'cifar100'        | train                 | valid + test              |
-        | 'ImageNet16-120'  | train                 | valid + test              |
-        |-------------------|-----------------------|---------------------------|
-
-        Legend:
-        * = [losses, acc1es, times]
+        The table above gives a detailed summary over the available splits, epochs, and which identifier are used per
+        dataset.
 
         Parameters
         ----------
@@ -251,7 +242,7 @@ class NasBench201BaseBenchmark(AbstractBenchmark):
         test_accuracies = [self.data[seed][structure_str]['eval_acc1es'][f'{valid_key}@{199}'] for seed in data_seed]
         test_losses = [self.data[seed][structure_str]['eval_losses'][f'{valid_key}@{199}'] for seed in data_seed]
         test_times = [np.sum((self.data[seed][structure_str]['eval_times'][f'{test_key}@{199}'])
-                              for e in range(1, epoch + 1)) for seed in data_seed]
+                             for e in range(1, epoch + 1)) for seed in data_seed]
 
         return {'function_value': float(100 - np.mean(valid_accuracies)),
                 'cost': float(np.sum(valid_times) + np.sum(train_times)),

--- a/hpobench/benchmarks/nas/tabular_benchmarks.py
+++ b/hpobench/benchmarks/nas/tabular_benchmarks.py
@@ -54,11 +54,12 @@ class FCNetBaseBenchmark(AbstractBenchmark):
         self.benchmark = benchmark
         self.data_path = data_path
 
+    # pylint: disable=arguments-differ
     @AbstractBenchmark._configuration_as_dict
     @AbstractBenchmark._check_configuration
     @AbstractBenchmark._check_fidelity
     def objective_function(self, configuration: Union[CS.Configuration, Dict],
-                           fidelity: Union[Dict, None] = None,
+                           fidelity: Union[CS.Configuration, Dict, None] = None,
                            run_index: Union[int, Tuple, None] = (0, 1, 2, 3),
                            rng: Union[np.random.RandomState, int, None] = None,
                            **kwargs) -> Dict:

--- a/hpobench/benchmarks/nas/tabular_benchmarks.py
+++ b/hpobench/benchmarks/nas/tabular_benchmarks.py
@@ -55,9 +55,7 @@ class FCNetBaseBenchmark(AbstractBenchmark):
         self.data_path = data_path
 
     # pylint: disable=arguments-differ
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
-    @AbstractBenchmark._check_fidelity
+    @AbstractBenchmark.check_parameters
     def objective_function(self, configuration: Union[CS.Configuration, Dict],
                            fidelity: Union[CS.Configuration, Dict, None] = None,
                            run_index: Union[int, Tuple, None] = (0, 1, 2, 3),
@@ -132,9 +130,7 @@ class FCNetBaseBenchmark(AbstractBenchmark):
                          'fidelity': fidelity},
                 }
 
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
-    @AbstractBenchmark._check_fidelity
+    @AbstractBenchmark.check_parameters
     def objective_function_test(self, configuration: Union[Dict, CS.Configuration],
                                 fidelity: Union[Dict, None] = None,
                                 rng: Union[np.random.RandomState, int, None] = None,

--- a/hpobench/benchmarks/rl/cartpole.py
+++ b/hpobench/benchmarks/rl/cartpole.py
@@ -93,9 +93,7 @@ class CartpoleBase(AbstractBenchmark):
 
         return fidel_space
 
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
-    @AbstractBenchmark._check_fidelity
+    @AbstractBenchmark.check_parameters
     def objective_function(self, configuration: Union[Dict, CS.Configuration],
                            fidelity: Union[Dict, CS.Configuration, None] = None,
                            rng: Union[np.random.RandomState, int, None] = None,
@@ -188,8 +186,7 @@ class CartpoleBase(AbstractBenchmark):
                          }
                 }
 
-    @AbstractBenchmark._check_configuration
-    @AbstractBenchmark._check_fidelity
+    @AbstractBenchmark.check_parameters
     def objective_function_test(self, configuration: Union[Dict, CS.Configuration],
                                 fidelity: Union[Dict, CS.Configuration, None] = None,
                                 rng: Union[np.random.RandomState, int, None] = None,

--- a/hpobench/benchmarks/rl/learna_benchmark.py
+++ b/hpobench/benchmarks/rl/learna_benchmark.py
@@ -381,7 +381,7 @@ class Learna(BaseLearna):
 class MetaLearna(BaseLearna):
     def __init__(self, data_path: Union[str, Path], rng: Union[np.random.RandomState, int, None] = None):
         super(MetaLearna, self).__init__(data_path=data_path, rng=rng)
-        self.config = hpolib.config.config_file
+        self.config = hpobench.config.config_file
 
     @staticmethod
     def get_fidelity_space(seed: Union[int, None] = None) -> CS.ConfigurationSpace:

--- a/hpobench/benchmarks/rl/learna_benchmark.py
+++ b/hpobench/benchmarks/rl/learna_benchmark.py
@@ -171,16 +171,14 @@ class BaseLearna(AbstractBenchmark):
 
         return config, network_config, agent_config, env_config
 
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
+    @AbstractBenchmark.check_parameters
     def objective_function(self, configuration: Union[CS.Configuration, Dict],
                            fidelity: Union[CS.Configuration, Dict, None] = None,
                            rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
         """ Interface for the objective function. """
         raise NotImplementedError()
 
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
+    @AbstractBenchmark.check_parameters
     def objective_function_test(self, configuration: Union[CS.Configuration, Dict],
                                 fidelity: Union[CS.Configuration, Dict, None] = None,
                                 rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
@@ -293,9 +291,7 @@ class Learna(BaseLearna):
     def __init__(self, data_path: Union[str, Path], rng: Union[np.random.RandomState, int, None] = None):
         super(Learna, self).__init__(data_path=data_path, rng=rng)
 
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
-    @AbstractBenchmark._check_fidelity
+    @AbstractBenchmark.check_parameters
     def objective_function(self, configuration: Union[CS.Configuration, Dict],
                            fidelity: Union[CS.Configuration, Dict, None] = None,
                            rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
@@ -348,9 +344,7 @@ class Learna(BaseLearna):
                          }
                 }
 
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
-    @AbstractBenchmark._check_fidelity
+    @AbstractBenchmark.check_parameters
     def objective_function_test(self, configuration: Union[CS.Configuration, Dict],
                                 fidelity: Union[CS.Configuration, Dict, None] = None,
                                 rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
@@ -412,8 +406,7 @@ class MetaLearna(BaseLearna):
 
         return fidel_space
 
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
+    @AbstractBenchmark.check_parameters
     def objective_function(self, configuration: Union[CS.Configuration, Dict],
                            fidelity: Union[CS.Configuration, Dict, None] = None,
                            rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
@@ -475,8 +468,7 @@ class MetaLearna(BaseLearna):
                          'fidelity': fidelity},
                 }
 
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
+    @AbstractBenchmark.check_parameters
     def objective_function_test(self, configuration: Union[CS.Configuration, Dict],
                                 fidelity: Union[CS.Configuration, Dict, None] = None,
                                 rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:

--- a/hpobench/benchmarks/surrogates/paramnet_benchmark.py
+++ b/hpobench/benchmarks/surrogates/paramnet_benchmark.py
@@ -129,8 +129,8 @@ class _ParamnetOnStepsBenchmark(_ParamnetBase):
         super(_ParamnetOnStepsBenchmark, self).__init__(rng=rng, dataset=dataset)
 
     @AbstractBenchmark.check_parameters
-    def objective_function(self, configuration: Union[Dict, CS.Configuration],
-                           fidelity: Union[Dict, None] = None,
+    def objective_function(self, configuration: Union[CS.Configuration, Dict],
+                           fidelity: Union[CS.Configuration, Dict, None] = None,
                            rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
         cfg_array = self.convert_config_to_array(configuration)
         lc = self.surrogate_objective.predict(cfg_array)[0]
@@ -145,8 +145,8 @@ class _ParamnetOnStepsBenchmark(_ParamnetBase):
                 'info': {'fidelity': fidelity}}
 
     @AbstractBenchmark.check_parameters
-    def objective_function_test(self, configuration: Union[Dict, CS.Configuration],
-                                fidelity: Union[Dict, None] = None,
+    def objective_function_test(self, configuration: Union[CS.Configuration, Dict],
+                                fidelity: Union[CS.Configuration, Dict, None] = None,
                                 rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
         assert fidelity['step'] == 50, f'Only querying a result for the 50. epoch is allowed, ' \
                                        f'but was {fidelity["step"]}.'
@@ -191,8 +191,8 @@ class _ParamnetOnStepsBenchmark(_ParamnetBase):
 class _ParamnetOnTimeBenchmark(_ParamnetBase):
 
     @AbstractBenchmark.check_parameters
-    def objective_function(self, configuration: Union[Dict, CS.Configuration],
-                           fidelity: Union[Dict, None] = None,
+    def objective_function(self, configuration: Union[CS.Configuration, Dict],
+                           fidelity: Union[CS.Configuration, Dict, None] = None,
                            rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
 
         config_array = self.convert_config_to_array(configuration)
@@ -225,8 +225,8 @@ class _ParamnetOnTimeBenchmark(_ParamnetBase):
                          'observed_epochs': len(lc)}}
 
     @AbstractBenchmark.check_parameters
-    def objective_function_test(self, configuration: Union[Dict, CS.Configuration],
-                                fidelity: Union[Dict, None] = None, shuffle: bool = False,
+    def objective_function_test(self, configuration: Union[CS.Configuration, Dict],
+                                fidelity: Union[CS.Configuration, Dict, None]  = None,
                                 rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
 
         assert fidelity['step'] == 50, f'Only querying a result for the 50. epoch is allowed, ' \

--- a/hpobench/benchmarks/surrogates/paramnet_benchmark.py
+++ b/hpobench/benchmarks/surrogates/paramnet_benchmark.py
@@ -128,9 +128,7 @@ class _ParamnetOnStepsBenchmark(_ParamnetBase):
         """
         super(_ParamnetOnStepsBenchmark, self).__init__(rng=rng, dataset=dataset)
 
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
-    @AbstractBenchmark._check_fidelity
+    @AbstractBenchmark.check_parameters
     def objective_function(self, configuration: Union[Dict, CS.Configuration],
                            fidelity: Union[Dict, None] = None,
                            rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
@@ -146,9 +144,7 @@ class _ParamnetOnStepsBenchmark(_ParamnetBase):
                 "cost": cost,
                 'info': {'fidelity': fidelity}}
 
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
-    @AbstractBenchmark._check_fidelity
+    @AbstractBenchmark.check_parameters
     def objective_function_test(self, configuration: Union[Dict, CS.Configuration],
                                 fidelity: Union[Dict, None] = None,
                                 rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
@@ -194,9 +190,7 @@ class _ParamnetOnStepsBenchmark(_ParamnetBase):
 
 class _ParamnetOnTimeBenchmark(_ParamnetBase):
 
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
-    @AbstractBenchmark._check_fidelity
+    @AbstractBenchmark.check_parameters
     def objective_function(self, configuration: Union[Dict, CS.Configuration],
                            fidelity: Union[Dict, None] = None,
                            rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
@@ -230,9 +224,7 @@ class _ParamnetOnTimeBenchmark(_ParamnetBase):
                 'info': {'learning_curve': lc.tolist(),
                          'observed_epochs': len(lc)}}
 
-    @AbstractBenchmark._configuration_as_dict
-    @AbstractBenchmark._check_configuration
-    @AbstractBenchmark._check_fidelity
+    @AbstractBenchmark.check_parameters
     def objective_function_test(self, configuration: Union[Dict, CS.Configuration],
                                 fidelity: Union[Dict, None] = None, shuffle: bool = False,
                                 rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:

--- a/hpobench/benchmarks/surrogates/paramnet_benchmark.py
+++ b/hpobench/benchmarks/surrogates/paramnet_benchmark.py
@@ -226,7 +226,7 @@ class _ParamnetOnTimeBenchmark(_ParamnetBase):
 
     @AbstractBenchmark.check_parameters
     def objective_function_test(self, configuration: Union[CS.Configuration, Dict],
-                                fidelity: Union[CS.Configuration, Dict, None]  = None,
+                                fidelity: Union[CS.Configuration, Dict, None] = None,
                                 rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
 
         assert fidelity['step'] == 50, f'Only querying a result for the 50. epoch is allowed, ' \

--- a/hpobench/config.py
+++ b/hpobench/config.py
@@ -33,6 +33,7 @@ class HPOBenchConfig:
         self.container_dir = None
         self.container_source = None
         self.use_global_data = None
+        self.pyro_connect_max_wait = None
 
         self.defaults = {'verbosity': 0,
                          'data_dir': self.config_base_dir,
@@ -79,15 +80,12 @@ class HPOBenchConfig:
 
     def __create_config_file(self):
         """ Create the configuration file. """
-        try:
-            self.logger.debug(f'Create a new config file here: {self.config_file}')
-            self.__check_dir(self.config_file.parent)
-            fh = self.config_file.open('w', encoding='utf-8')
-            for k in self.defaults:
-                fh.write(f'{k}={self.defaults[k]}\n')
-            fh.close()
-        except (IOError, OSError):
-            raise
+        self.logger.debug(f'Create a new config file here: {self.config_file}')
+        self.__check_dir(self.config_file.parent)
+        fh = self.config_file.open('w', encoding='utf-8')
+        for k in self.defaults:
+            fh.write(f'{k}={self.defaults[k]}\n')
+        fh.close()
 
     def __parse_config(self):
         """ Parse the config file """

--- a/hpobench/config.py
+++ b/hpobench/config.py
@@ -1,10 +1,11 @@
 import ast
-import configparser
 import logging
 import os
-from io import StringIO
 from pathlib import Path
-from typing import Union, Any
+
+import yaml
+
+from hpobench import __version__
 
 
 class HPOBenchConfig:
@@ -23,31 +24,42 @@ class HPOBenchConfig:
 
         # According to https://github.com/openml/openml-python/issues/884, try to set default directories.
         self.config_base_dir = Path(os.environ.get('XDG_CONFIG_HOME', '~/.config/hpobench')).expanduser()
+
+        # The path to the hpobenchrc file
         self.config_file = self.config_base_dir / '.hpobenchrc'
+        self.config_file = self.config_file.expanduser().absolute()
+
+        # The configuration file should have the same version as the hpobench. Raise a warning if there is a version
+        # mismatch. We want to make sure that the configuration file is up to date with the hpobench, because it is
+        # possible that something in the configuration has changed but the old hpobenchrc file is still there and prohibit
+        # the changes. Ignore the dev tag if available.
+        self.config_version = __version__.rstrip('dev')
+
+        # Set the default logging level.
+        # Possible levels are 0 = NOTSET (warning), 10 = DEBUG, 20 = INFO, 30 = WARNING, 40 = ERROR, 50 = CRITICAL
+        # See also https://docs.python.org/3/library/logging.html#logging-levels
+        self.verbosity = 0
+
+        # The cache dir contains the lock files etc
         self.cache_dir = Path(os.environ.get('XDG_CACHE_HOME', '~/.cache/hpobench')).expanduser()
+
+        # The user can specify if the local or a more global data directory should be used. This is helpful when working
+        # on a cluster
+        self.data_dir = self.config_base_dir
         self.global_data_dir = Path(os.environ.get('XDG_DATA_HOME', '~/.local/share/hpobench')).expanduser()
+        self.use_global_data = True
 
-        self.config = None
-        self.data_dir = None
-        self.socket_dir = Path("/tmp")
-        self.container_dir = None
-        self.container_source = None
-        self.use_global_data = None
-        self.pyro_connect_max_wait = None
+        # Options for the singularity container
+        # Find all hosted container on: https://cloud.sylabs.io/library/phmueller/automl
+        self.socket_dir = Path('/tmp')
+        self.container_dir = self.cache_dir / f'hpobench-{os.getuid()}'
+        self.container_source = 'library://phmueller/automl'
+        self.pyro_connect_max_wait = 400
 
-        self.defaults = {'verbosity': 0,
-                         'data_dir': self.config_base_dir,
-                         'socket_dir': self.socket_dir,
-                         'container_dir': self.cache_dir / f'hpobench-{os.getuid()}',
-                         # Find all hosted container on:
-                         # https://cloud.sylabs.io/library/phmueller/automl
-                         'container_source': 'library://phmueller/automl',
-                         'use_global_data': True,
-                         'pyro_connect_max_wait': 400}
+        # Read in the hpobenchrc file and set the default values if not specified
+        self._setup()
 
-        self._setup(self.config_file)
-
-    def _setup(self, config_file: Union[Path, str]):
+    def _setup(self):
         """ Sets up config. Reads the config file and parses it.
 
         Parameters:
@@ -57,18 +69,11 @@ class HPOBenchConfig:
             Path to config file
         """
 
-        # Change current config file to new config file
-        config_file = Path(config_file).expanduser().absolute()
-
-        if config_file != self.config_file:
-            self.logger.debug(f'Change config file from {self.config_file} to {config_file}')
-            self.config_file = config_file
-
         # Create an empty config file if there was none so far
         if not self.config_file.exists():
             self.__create_config_file()
 
-        # Parse config and store input in self.config
+        # Parse config
         self.__parse_config()
 
         # Check whether data_dir exists, if not create it
@@ -82,46 +87,65 @@ class HPOBenchConfig:
         """ Create the configuration file. """
         self.logger.debug(f'Create a new config file here: {self.config_file}')
         self.__check_dir(self.config_file.parent)
-        fh = self.config_file.open('w', encoding='utf-8')
-        for k in self.defaults:
-            fh.write(f'{k}={self.defaults[k]}\n')
-        fh.close()
+
+        defaults = {'version': self.config_version,
+                    'verbosity': self.verbosity,
+                    'cache_dir': str(self.cache_dir),
+                    'data_dir': str(self.data_dir),
+                    'global_data_dir': str(self.global_data_dir),
+                    'use_global_data': True,
+                    'socket_dir': str(self.socket_dir),
+                    'container_dir': str(self.container_dir),
+                    'container_source': self.container_source,
+                    'pyro_connect_max_wait': self.pyro_connect_max_wait
+                    }
+
+        with self.config_file.open('w', encoding='utf-8') as fh:
+            yaml.dump(defaults, fh)
 
     def __parse_config(self):
         """ Parse the config file """
-        config = configparser.RawConfigParser()
+        with self.config_file.open('r') as fh:
+            read_config = yaml.load(fh, Loader=yaml.FullLoader)
 
-        # Cheat the ConfigParser module by adding a fake section header
-        config_file_ = StringIO()
-        config_file_.write('[FAKE_SECTION]\n')
-        with self.config_file.open('r', encoding='utf-8') as fh:
-            for line in fh:
-                config_file_.write(line)
-        config_file_.seek(0)
-        config.read_file(config_file_)
-        self.config = config
+        # The old hpolibrc was parsed with the configparser. But this required to use fake sections, etc. We moved to
+        # pyyaml. Yaml returns a string if the rc file is not in yaml format.
+        if isinstance(read_config, str):
+            logging.warning('The hpobenchrc can not be parsed. This is likely due to a change in the hpobenchrc format.'
+                            f' Please remove the old hpobenchrc. The hpobenchrc file is in {self.config_file}')
 
-        # Store configuration
-        self.data_dir = Path(self.__get_config_option('data_dir'))
-        self.socket_dir = Path(self.__get_config_option('socket_dir'))
-        self.container_dir = Path(self.__get_config_option('container_dir'))
-        self.container_source = self.__get_config_option('container_source')
-        self.use_global_data = self.__get_config_option('use_global_data')
-        if type(self.use_global_data) is str:
+        self.config_version = read_config.get('version')
+        self._check_version()
+
+        self.verbosity = read_config.get('verbosity', self.verbosity)
+        logging.basicConfig(level=self.verbosity)
+
+        self.cache_dir = Path(read_config.get('cache_dir', self.cache_dir))
+        self.data_dir = Path(read_config.get('data_dir', self.data_dir))
+        self.global_data_dir = Path(read_config.get('global_data_dir', self.global_data_dir))
+        self.use_global_data = read_config.get('use_global_data', self.use_global_data)
+
+        if isinstance(self.use_global_data, str):
             self.use_global_data = ast.literal_eval(self.use_global_data)
-        self.pyro_connect_max_wait = int(self.__get_config_option('pyro_connect_max_wait'))
 
-        # Use global data dir if exist
         if self.global_data_dir.is_dir() and self.use_global_data:
             self.data_dir = self.global_data_dir
 
-    def __get_config_option(self, o: str) -> Any:
-        """ Try to get config option from configuration file. If the option is
-            not configured, use default """
-        try:
-            return self.config.get('FAKE_SECTION', o)
-        except configparser.NoOptionError:
-            return self.defaults[o]
+        self.socket_dir = Path(read_config.get('socket_dir', self.socket_dir))
+        self.container_dir = Path(read_config.get('container_dir', self.container_dir))
+        self.container_source = read_config.get('container_source', self.container_source)
+        self.pyro_connect_max_wait = int(read_config.get('pyro_connect_max_wait',
+                                                         self.pyro_connect_max_wait))
+
+    def _check_version(self):
+        """ Check if the version of the configuration file matches the hpobench version.
+            Ignore the `dev` tag at the end.
+        """
+        if self.config_version is None or not __version__.startswith(self.config_version):
+            self.config_version = self.config_version if not None else 'None'
+            logging.warning(f'The hpobenchrc file was created with another version of the hpobench. '
+                            f'Current version of the hpobenchrc file: {self.config_version}.\n'
+                            f'Current version of the hpobench: {__version__}')
 
     def __check_dir(self, path: Path):
         """ Check whether dir exists and if not create it"""

--- a/hpobench/config.py
+++ b/hpobench/config.py
@@ -32,8 +32,8 @@ class HPOBenchConfig:
 
         # The configuration file should have the same version as the hpobench. Raise a warning if there is a version
         # mismatch. We want to make sure that the configuration file is up to date with the hpobench, because it is
-        # possible that something in the configuration has changed but the old hpobenchrc file is still there and prohibit
-        # the changes. Ignore the dev tag if available.
+        # possible that something in the configuration has changed but the old hpobenchrc file is still there and
+        # prohibit the changes. Ignore the dev tag if available.
         self.config_version = __version__.rstrip('dev')
 
         # Set the default logging level.
@@ -112,7 +112,7 @@ class HPOBenchConfig:
         try:
             with self.config_file.open('r') as fh:
                 read_config = yaml.load(fh, Loader=yaml.FullLoader)
-        except ParserError as e:
+        except ParserError:
             raise ParserError(failure_msg)
 
         # The old hpolibrc was parsed with the configparser. But this required to use fake sections, etc. We moved to

--- a/hpobench/config.py
+++ b/hpobench/config.py
@@ -124,7 +124,8 @@ class HPOBenchConfig:
         self._check_version()
 
         self.verbosity = read_config.get('verbosity', self.verbosity)
-        logging.basicConfig(level=self.verbosity)
+        # logging.basicConfig(level=self.verbosity)  # TODO: This statement causes some trouble.
+        #                                                    (Container-Logger is always set to debug)
 
         self.cache_dir = Path(read_config.get('cache_dir', self.cache_dir))
         self.data_dir = Path(read_config.get('data_dir', self.data_dir))

--- a/hpobench/container/benchmarks/ml/svm_benchmark.py
+++ b/hpobench/container/benchmarks/ml/svm_benchmark.py
@@ -7,7 +7,8 @@ from hpobench.container.client_abstract_benchmark import AbstractBenchmarkClient
 
 
 class SupportVectorMachine(AbstractBenchmarkClient):
-    def __init__(self, **kwargs):
+    def __init__(self, task_id: int, **kwargs):
+        kwargs['task_id'] = task_id
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'SupportVectorMachine')
         kwargs['container_name'] = kwargs.get('container_name', 'svm_benchmark')
         super(SupportVectorMachine, self).__init__(**kwargs)

--- a/hpobench/container/benchmarks/ml/xgboost_benchmark.py
+++ b/hpobench/container/benchmarks/ml/xgboost_benchmark.py
@@ -7,7 +7,8 @@ from hpobench.container.client_abstract_benchmark import AbstractBenchmarkClient
 
 
 class XGBoostBenchmark(AbstractBenchmarkClient):
-    def __init__(self, **kwargs):
+    def __init__(self, task_id: int, **kwargs):
+        kwargs['task_id'] = task_id
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'XGBoostBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'xgboost_benchmark')
         super(XGBoostBenchmark, self).__init__(**kwargs)

--- a/hpobench/container/benchmarks/nas/nasbench_201.py
+++ b/hpobench/container/benchmarks/nas/nasbench_201.py
@@ -6,13 +6,6 @@
 from hpobench.container.client_abstract_benchmark import AbstractBenchmarkClient
 
 
-class Cifar10NasBench201Benchmark(AbstractBenchmarkClient):
-    def __init__(self, **kwargs):
-        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'Cifar10NasBench201Benchmark')
-        kwargs['container_name'] = kwargs.get('container_name', 'nasbench_201')
-        super(Cifar10NasBench201Benchmark, self).__init__(**kwargs)
-
-
 class Cifar10ValidNasBench201Benchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'Cifar10ValidNasBench201Benchmark')

--- a/hpobench/container/client_abstract_benchmark.py
+++ b/hpobench/container/client_abstract_benchmark.py
@@ -355,8 +355,13 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
 
     def _shutdown(self):
         """ Shutdown benchmark and stop container"""
-        self.benchmark.shutdown()
+        try:
+            self.benchmark.shutdown()
+        except TypeError:
+            pass
+
         subprocess.run(f'singularity instance stop {self.socket_id}'.split(), check=False)
+
         if (self.config.socket_dir / f'{self.socket_id}_unix.sock').exists():
             (self.config.socket_dir / f'{self.socket_id}_unix.sock').unlink()
         # self.benchmark._pyroRelease()

--- a/hpobench/container/client_abstract_benchmark.py
+++ b/hpobench/container/client_abstract_benchmark.py
@@ -23,7 +23,7 @@ import subprocess
 import time
 from pathlib import Path
 from typing import Optional
-from typing import Union, Dict, List
+from typing import Union, Dict
 from uuid import uuid1
 
 import ConfigSpace as CS

--- a/hpobench/container/server_abstract_benchmark.py
+++ b/hpobench/container/server_abstract_benchmark.py
@@ -143,5 +143,5 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # pylint: disable=logging-fstring-interpolation
-    exec(f"from hpolib.benchmarks.{args.importBase} import {args.benchmark} as Benchmark")
+    exec(f"from hpobench.benchmarks.{args.importBase} import {args.benchmark} as Benchmark")
     bp = BenchmarkServer(args.socket_id)

--- a/hpobench/container/server_abstract_benchmark.py
+++ b/hpobench/container/server_abstract_benchmark.py
@@ -22,13 +22,13 @@ from hpobench.util.container_utils import BenchmarkEncoder, BenchmarkDecoder
 
 # Read in the verbosity level from the environment variable HPOBENCH_DEBUG
 log_level_str = os.environ.get('HPOBENCH_DEBUG', 'false')
-log_level = logging.DEBUG if log_level_str == 'true' else logging.INFO
+LOG_LEVEL = logging.DEBUG if log_level_str == 'true' else logging.INFO
 
 console = logging.StreamHandler()
-console.setLevel(log_level)
+console.setLevel(LOG_LEVEL)
 
 logger = logging.getLogger('BenchmarkServer')
-logger.setLevel(log_level)
+logger.setLevel(LOG_LEVEL)
 logger.addHandler(console)
 
 
@@ -36,7 +36,7 @@ logger.addHandler(console)
 @Pyro4.behavior(instance_mode="single")
 class BenchmarkServer:
     def __init__(self, socket_id):
-        self.pyroRunning = True
+        self.pyro_running = True
         config = HPOBenchConfig()
         self.benchmark = None
 
@@ -49,7 +49,7 @@ class BenchmarkServer:
         _ = self.daemon.register(self, self.socket_id + ".unixsock")
 
         # start the event loop of the server to wait for calls
-        self.daemon.requestLoop(loopCondition=lambda: self.pyroRunning)
+        self.daemon.requestLoop(loopCondition=lambda: self.pyro_running)
 
     def init_benchmark(self, kwargs_str):
         try:
@@ -123,7 +123,7 @@ class BenchmarkServer:
     def shutdown(self):
         logger.debug('Server: Shutting down...')
         Pyro4.config.COMMTIMEOUT = 0.5
-        self.pyroRunning = False
+        self.pyro_running = False
         self.daemon.shutdown()
 
 
@@ -142,5 +142,6 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    exec(f"from hpobench.benchmarks.{args.importBase} import {args.benchmark} as Benchmark")
+    # pylint: disable=logging-fstring-interpolation
+    exec(f"from hpolib.benchmarks.{args.importBase} import {args.benchmark} as Benchmark")
     bp = BenchmarkServer(args.socket_id)

--- a/hpobench/container/server_abstract_benchmark.py
+++ b/hpobench/container/server_abstract_benchmark.py
@@ -62,7 +62,7 @@ class BenchmarkServer:
     def get_configuration_space(self, kwargs_str: str) -> str:
         logger.debug(f'Server: get_config_space: kwargs_str: {kwargs_str}')
 
-        kwargs = json.loads(kwargs_str)
+        kwargs = json.loads(kwargs_str, cls=BenchmarkDecoder)
         seed = kwargs.get('seed', None)
 
         result = self.benchmark.get_configuration_space(seed=seed)
@@ -72,35 +72,19 @@ class BenchmarkServer:
     def get_fidelity_space(self, kwargs_str: str) -> str:
         logger.debug(f'Server: get_fidelity_space: kwargs_str: {kwargs_str}')
 
-        kwargs = json.loads(kwargs_str)
+        kwargs = json.loads(kwargs_str, cls=BenchmarkDecoder)
         seed = kwargs.get('seed', None)
 
         result = self.benchmark.get_fidelity_space(seed=seed)
         logger.debug(f'Server: Fidelity Space: {result}')
         return csjson.write(result, indent=None)
 
-    def objective_function_list(self, c_str: str, f_str: str, kwargs_str: str) -> str:
-        configuration = json.loads(c_str)
-        fidelity = json.loads(f_str)
-        kwargs = json.loads(kwargs_str)
-
-        result = self.benchmark.objective_function(configuration=configuration, fidelity=fidelity, **kwargs)
-        return json.dumps(result, indent=None, cls=BenchmarkEncoder)
-
-    def objective_function_test_list(self, c_str: str, f_str: str, kwargs_str: str) -> str:
-        configuration = json.loads(c_str)
-        fidelity = json.loads(f_str)
-        kwargs = json.loads(kwargs_str)
-
-        result = self.benchmark.objective_function_test(configuration=configuration, fidelity=fidelity, **kwargs)
-        return json.dumps(result, indent=None, cls=BenchmarkEncoder)
-
     def objective_function(self, c_str: str, f_str: str, kwargs_str: str) -> str:
         logger.debug(f'Server: objective_function: c_str: {c_str} f_str: {f_str} kwargs_str: {kwargs_str}')
 
-        configuration = json.loads(c_str)
-        fidelity = json.loads(f_str)
-        kwargs = json.loads(kwargs_str)
+        configuration = json.loads(c_str, cls=BenchmarkDecoder)
+        fidelity = json.loads(f_str, cls=BenchmarkDecoder)
+        kwargs = json.loads(kwargs_str, cls=BenchmarkDecoder)
 
         result = self.benchmark.objective_function(configuration=configuration, fidelity=fidelity, **kwargs)
         return json.dumps(result, indent=None, cls=BenchmarkEncoder)
@@ -108,9 +92,9 @@ class BenchmarkServer:
     def objective_function_test(self, c_str: str, f_str: str, kwargs_str: str) -> str:
         logger.debug(f'Server: objective_function: c_str: {c_str} f_str: {f_str} kwargs_str: {kwargs_str}')
 
-        configuration = json.loads(c_str)
-        fidelity = json.loads(f_str)
-        kwargs = json.loads(kwargs_str)
+        configuration = json.loads(c_str, cls=BenchmarkDecoder)
+        fidelity = json.loads(f_str, cls=BenchmarkDecoder)
+        kwargs = json.loads(kwargs_str, cls=BenchmarkDecoder)
 
         result = self.benchmark.objective_function_test(configuration=configuration, fidelity=fidelity, **kwargs)
         return json.dumps(result, indent=None, cls=BenchmarkEncoder)

--- a/hpobench/container/server_abstract_benchmark.py
+++ b/hpobench/container/server_abstract_benchmark.py
@@ -24,12 +24,12 @@ from hpobench.util.container_utils import BenchmarkEncoder, BenchmarkDecoder
 log_level_str = os.environ.get('HPOBENCH_DEBUG', 'false')
 LOG_LEVEL = logging.DEBUG if log_level_str == 'true' else logging.INFO
 
-console = logging.StreamHandler()
-console.setLevel(LOG_LEVEL)
+# console = logging.StreamHandler()
+# console.setLevel(LOG_LEVEL)
 
 logger = logging.getLogger('BenchmarkServer')
 logger.setLevel(LOG_LEVEL)
-logger.addHandler(console)
+# logger.addHandler(console)
 
 
 @Pyro4.expose

--- a/hpobench/container/server_abstract_benchmark.py
+++ b/hpobench/container/server_abstract_benchmark.py
@@ -10,16 +10,15 @@ that all payloads are json-serializable.
 """
 
 import argparse
-import enum
 import json
 import logging
 import os
 
 import Pyro4
-import numpy as np
 from ConfigSpace.read_and_write import json as csjson
 
 from hpobench.config import HPOBenchConfig
+from hpobench.util.container_utils import BenchmarkEncoder, BenchmarkDecoder
 
 # Read in the verbosity level from the environment variable HPOBENCH_DEBUG
 log_level_str = os.environ.get('HPOBENCH_DEBUG', 'false')
@@ -31,8 +30,6 @@ console.setLevel(log_level)
 logger = logging.getLogger('BenchmarkServer')
 logger.setLevel(log_level)
 logger.addHandler(console)
-
-from hpobench.util.container_utils import BenchmarkEncoder, BenchmarkDecoder
 
 
 @Pyro4.expose

--- a/hpobench/util/container_utils.py
+++ b/hpobench/util/container_utils.py
@@ -15,10 +15,9 @@ class BenchmarkEncoder(json.JSONEncoder):
 
     Serializing tuple/numpy array may not work. We need to annotate those types, to reconstruct them correctly.
     """
+    # pylint: disable=arguments-differ
     def encode(self, obj):
         def hint(item):
-            # TODO: Currently basic python int and floats are casted to numpy ints and floats!!
-
             # Annotate the different item types
             if isinstance(item, tuple):
                 return {'__type__': 'tuple', '__items__': [hint(e) for e in item]}

--- a/hpobench/util/container_utils.py
+++ b/hpobench/util/container_utils.py
@@ -25,12 +25,12 @@ class BenchmarkEncoder(json.JSONEncoder):
             if isinstance(item, np.float):
                 return {'__type__': 'np.float', '__items__': item}
             if isinstance(item, np.ndarray):
-                return {'__type__': 'np.int','__items__': item}
+                return {'__type__': 'np.int', '__items__': item}
             if isinstance(item, enum.Enum):
                 return str(item)
             if isinstance(item, np.random.RandomState):
                 rs = serialize_random_state(item)
-                return {'__type__': 'random_state','__items__': rs}
+                return {'__type__': 'random_state', '__items__': rs}
 
             # If it is a container data structure, go also through the items.
             if isinstance(item, list):

--- a/hpobench/util/container_utils.py
+++ b/hpobench/util/container_utils.py
@@ -17,15 +17,17 @@ class BenchmarkEncoder(json.JSONEncoder):
     """
     def encode(self, obj):
         def hint(item):
+            # TODO: Currently basic python int and floats are casted to numpy ints and floats!!
+
             # Annotate the different item types
             if isinstance(item, tuple):
                 return {'__type__': 'tuple', '__items__': [hint(e) for e in item]}
             if isinstance(item, np.ndarray):
-                return {'__type__': 'np.ndarray', '__items__': item}
+                return {'__type__': 'np.ndarray', '__items__': int(item)}
             if isinstance(item, np.float):
-                return {'__type__': 'np.float', '__items__': item}
+                return {'__type__': 'np.float', '__items__': float(item)}
             if isinstance(item, np.ndarray):
-                return {'__type__': 'np.int', '__items__': item}
+                return {'__type__': 'np.int', '__items__': item.tolist()}
             if isinstance(item, enum.Enum):
                 return str(item)
             if isinstance(item, np.random.RandomState):

--- a/hpobench/util/container_utils.py
+++ b/hpobench/util/container_utils.py
@@ -23,10 +23,10 @@ class BenchmarkEncoder(json.JSONEncoder):
             if isinstance(item, tuple):
                 return {'__type__': 'tuple', '__items__': [hint(e) for e in item]}
             if isinstance(item, np.ndarray):
-                return {'__type__': 'np.ndarray', '__items__': int(item)}
-            if isinstance(item, np.float):
+                return {'__type__': 'np.ndarray', '__items__': item.tolist()}
+            if isinstance(item, np.floating):
                 return {'__type__': 'np.float', '__items__': float(item)}
-            if isinstance(item, np.ndarray):
+            if isinstance(item, np.integer):
                 return {'__type__': 'np.int', '__items__': item.tolist()}
             if isinstance(item, enum.Enum):
                 return str(item)

--- a/hpobench/util/data_manager.py
+++ b/hpobench/util/data_manager.py
@@ -9,6 +9,8 @@ For OpenML data sets (defined by task id or similar) please use the
 hpobench.util.openml_data_manager.
 """
 
+# pylint: disable=logging-fstring-interpolation,invalid-name
+
 import abc
 import gzip
 import logging
@@ -33,7 +35,7 @@ except ImportError:
 import hpobench
 
 
-class DataManager(object, metaclass=abc.ABCMeta):
+class DataManager(abc.ABC, metaclass=abc.ABCMeta):
     """ Base Class for loading and managing the data.
 
     Attributes
@@ -72,8 +74,8 @@ class HoldoutDataManager(DataManager):
     ----------
     X_train : np.ndarray
     y_train : np.ndarray
-    X_val : np.ndarray
-    y_val : np.ndarray
+    X_valid : np.ndarray
+    y_valid : np.ndarray
     X_test : np.ndarray
     y_test : np.ndarray
     """
@@ -83,8 +85,8 @@ class HoldoutDataManager(DataManager):
 
         self.X_train = None
         self.y_train = None
-        self.X_val = None
-        self.y_val = None
+        self.X_valid = None
+        self.y_valid = None
         self.X_test = None
         self.y_test = None
 
@@ -421,6 +423,7 @@ class SVHNData(DataManager):
             else:
                 self.logger.debug(f"Load data {save_fl}")
 
+            # pylint: disable=import-outside-toplevel
             from scipy.io import loadmat
             data = loadmat(save_fl)
 

--- a/hpobench/util/data_manager.py
+++ b/hpobench/util/data_manager.py
@@ -458,12 +458,12 @@ class NASBench_201Data(DataManager):
         dataset : str
             One of cifar10, cifar10-valid, cifar100, ImageNet16-120
         """
-        all_datasets = ['cifar10', 'cifar10-valid', 'cifar100', 'ImageNet16-120']
+        all_datasets = ['cifar10-valid', 'cifar100', 'ImageNet16-120']
         assert dataset in all_datasets, f'data set {dataset} unknown'
 
         super(NASBench_201Data, self).__init__()
 
-        self.files = [f'NAS-Bench-201-v1_1-096897_{dataset}.pth' for dataset in all_datasets]
+        self.files = [f'NAS-Bench-201-v1_1-096897_{dataset}.json' for dataset in all_datasets]
         self._save_dir = hpobench.config_file.data_dir / "nasbench_201"
         self.filename = f'NAS-Bench-201-v1_1-096897_{dataset}.json'
 

--- a/hpobench/util/data_manager.py
+++ b/hpobench/util/data_manager.py
@@ -455,35 +455,19 @@ class NASBench_201Data(DataManager):
         dataset : str
             One of cifar10, cifar10-valid, cifar100, ImageNet16-120
         """
-        assert dataset in ['cifar10', 'cifar10-valid', 'cifar100', 'ImageNet16-120']
+        all_datasets = ['cifar10', 'cifar10-valid', 'cifar100', 'ImageNet16-120']
+        assert dataset in all_datasets
 
         super(NASBench_201Data, self).__init__()
 
-        self.files = self.get_files_per_dataset(dataset)
+        self.files = [f'NAS-Bench-201-v1_1-096897_{dataset}.pth' for dataset in all_datasets]
         self._save_dir = hpobench.config_file.data_dir / "nasbench_201"
+        self.filename = f'NAS-Bench-201-v1_1-096897_{dataset}.json'
+
         self._url_source = 'https://www.automl.org/wp-content/uploads/2020/08/nasbench_201_data_v1.2.zip'
         self.data = {}
 
         self.create_save_directory(self._save_dir)
-
-    @staticmethod
-    def get_seeds_metrics():
-        from itertools import product
-        seeds = [777, 888, 999]
-        metrics = NASBench_201Data.get_metrics()
-        return product(seeds, metrics)
-
-    @staticmethod
-    def get_metrics():
-        return ['train_acc1es', 'train_losses', 'train_times',
-                'valid_acc1es', 'valid_times', 'valid_losses',
-                'test_acc1es', 'test_times', 'test_losses']
-
-    @staticmethod
-    def get_files_per_dataset(dataset):
-        seeds_metrics = NASBench_201Data.get_seeds_metrics()
-        files = [f'nb201_{dataset}_{seed}_{metric}.pkl' for seed, metric in seeds_metrics]
-        return files
 
     @lockutils.synchronized('not_thread_process_safe', external=True,
                             lock_path=f'{hpobench.config_file.cache_dir}/lock_nasbench_201_data', delay=0.5)
@@ -504,12 +488,10 @@ class NASBench_201Data(DataManager):
 
     def _load(self) -> Dict:
         """ Load the data from the file system """
-        import pickle
-        data = {}
-        for (seed, metric_name), file in zip(NASBench_201Data.get_seeds_metrics(), self.files):
-            with (self._save_dir / file).open('rb') as fh:
-                metric = pickle.load(fh)
-                data[(seed, metric_name)] = metric
+        import json
+
+        with (self._save_dir / self.filename).open('rb') as fh:
+               data = json.load(fh)
 
         return data
 

--- a/hpobench/util/data_manager.py
+++ b/hpobench/util/data_manager.py
@@ -456,7 +456,7 @@ class NASBench_201Data(DataManager):
             One of cifar10, cifar10-valid, cifar100, ImageNet16-120
         """
         all_datasets = ['cifar10', 'cifar10-valid', 'cifar100', 'ImageNet16-120']
-        assert dataset in all_datasets
+        assert dataset in all_datasets, f'data set {dataset} unknown'
 
         super(NASBench_201Data, self).__init__()
 
@@ -464,7 +464,7 @@ class NASBench_201Data(DataManager):
         self._save_dir = hpobench.config_file.data_dir / "nasbench_201"
         self.filename = f'NAS-Bench-201-v1_1-096897_{dataset}.json'
 
-        self._url_source = 'https://www.automl.org/wp-content/uploads/2020/08/nasbench_201_data_v1.2.zip'
+        self._url_source = 'https://www.automl.org/wp-content/uploads/2020/08/nasbench_201_data_v1.3.zip'
         self.data = {}
 
         self.create_save_directory(self._save_dir)
@@ -491,7 +491,7 @@ class NASBench_201Data(DataManager):
         import json
 
         with (self._save_dir / self.filename).open('rb') as fh:
-               data = json.load(fh)
+            data = json.load(fh)
 
         return data
 

--- a/hpobench/util/example_utils.py
+++ b/hpobench/util/example_utils.py
@@ -3,14 +3,14 @@ from pathlib import Path
 from typing import Dict
 
 
-def get_travis_settings(type: str) -> Dict:
+def get_travis_settings(optimizer_type: str) -> Dict:
     """ Helper function to reduce time consumption for test runs on travis.ci"""
-    if type == 'smac':
+    if optimizer_type == 'smac':
         return {"runcount-limit": 5, 'wallclock-limit': 50, 'cutoff': 50, 'memory_limit': 10000, 'output_dir': '.'}
-    elif type == 'bohb':
+    if optimizer_type == 'bohb':
         return {'max_budget': 2, 'num_iterations': 1, 'output_dir': Path('./')}
-    else:
-        raise ValueError(f'Unknown type {type}. Must be one of [smac, bohb]')
+
+    raise ValueError(f'Unknown type {optimizer_type}. Must be one of [smac, bohb]')
 
 
 def set_env_variables_to_use_only_one_core():

--- a/hpobench/util/openml_data_manager.py
+++ b/hpobench/util/openml_data_manager.py
@@ -181,14 +181,14 @@ class OpenMLHoldoutDataManager(HoldoutDataManager):
         categories = [np.concatenate([replace_value.flatten(), cat])
                       for (replace_value, cat) in zip(replace_nans_with, categories)]
 
-        def _find_and_replace(array, replace_nans_with, categorical_data):
+        def _find_and_replace(array, replace_nans_with):
             nan_idx = np.where(np.isnan(array))
             array[nan_idx] = np.take(replace_nans_with, nan_idx[1])
             return array
 
-        X_train[:, is_categorical] = _find_and_replace(X_train[:, is_categorical], replace_nans_with, is_categorical)
-        X_valid[:, is_categorical] = _find_and_replace(X_valid[:, is_categorical], replace_nans_with, is_categorical)
-        X_test[:, is_categorical] = _find_and_replace(X_test[:, is_categorical], replace_nans_with, is_categorical)
+        X_train[:, is_categorical] = _find_and_replace(X_train[:, is_categorical], replace_nans_with)
+        X_valid[:, is_categorical] = _find_and_replace(X_valid[:, is_categorical], replace_nans_with)
+        X_test[:, is_categorical] = _find_and_replace(X_test[:, is_categorical], replace_nans_with)
         return X_train, X_valid, X_test, categories
 
 

--- a/hpobench/util/rng_helper.py
+++ b/hpobench/util/rng_helper.py
@@ -27,10 +27,9 @@ def get_rng(rng: Union[int, np.random.RandomState, None] = None,
 
     if rng is not None:
         return _cast_int_to_random_state(rng)
-    elif rng is None and self_rng is not None:
+    if rng is None and self_rng is not None:
         return _cast_int_to_random_state(self_rng)
-    else:
-        return np.random.RandomState()
+    return np.random.RandomState()
 
 
 def _cast_int_to_random_state(rng: Union[int, np.random.RandomState]) -> np.random.RandomState:
@@ -47,11 +46,10 @@ def _cast_int_to_random_state(rng: Union[int, np.random.RandomState]) -> np.rand
     """
     if isinstance(rng, np.random.RandomState):
         return rng
-    elif int(rng) == rng:
+    if int(rng) == rng:
         # As seed is sometimes -1 (e.g. if SMAC optimizes a deterministic function) -> use abs()
         return np.random.RandomState(np.abs(rng))
-    else:
-        raise ValueError(f"{rng} is neither a number nor a RandomState. Initializing RandomState failed")
+    raise ValueError(f"{rng} is neither a number nor a RandomState. Initializing RandomState failed")
 
 
 def serialize_random_state(random_state: np.random.RandomState) -> Tuple[int, List, int, int, int]:

--- a/hpobench/util/rng_helper.py
+++ b/hpobench/util/rng_helper.py
@@ -52,3 +52,17 @@ def _cast_int_to_random_state(rng: Union[int, np.random.RandomState]) -> np.rand
         return np.random.RandomState(np.abs(rng))
     else:
         raise ValueError(f"{rng} is neither a number nor a RandomState. Initializing RandomState failed")
+
+
+def serialize_random_state(random_state):
+    (rnd0, rnd1, rnd2, rnd3, rnd4) = random_state.get_state()
+    rnd1 = rnd1.tolist()
+    return rnd0, rnd1, rnd2, rnd3, rnd4
+
+
+def deserialize_random_state(random_state_str):
+    (rnd0, rnd1, rnd2, rnd3, rnd4) = random_state_str
+    rnd1 = [np.uint32(number) for number in rnd1]
+    random_state = np.random.RandomState()
+    random_state.set_state((rnd0, rnd1, rnd2, rnd3, rnd4))
+    return random_state

--- a/hpobench/util/rng_helper.py
+++ b/hpobench/util/rng_helper.py
@@ -1,5 +1,5 @@
 """ Helper functions to easily obtain randomState """
-from typing import Union
+from typing import Union, Tuple, List
 
 import numpy as np
 
@@ -54,14 +54,14 @@ def _cast_int_to_random_state(rng: Union[int, np.random.RandomState]) -> np.rand
         raise ValueError(f"{rng} is neither a number nor a RandomState. Initializing RandomState failed")
 
 
-def serialize_random_state(random_state):
+def serialize_random_state(random_state: np.random.RandomState) -> Tuple[int, List, int, int, int]:
     (rnd0, rnd1, rnd2, rnd3, rnd4) = random_state.get_state()
     rnd1 = rnd1.tolist()
     return rnd0, rnd1, rnd2, rnd3, rnd4
 
 
-def deserialize_random_state(random_state_str):
-    (rnd0, rnd1, rnd2, rnd3, rnd4) = random_state_str
+def deserialize_random_state(random_state: Tuple[int, List, int, int, int]) -> np.random.RandomState:
+    (rnd0, rnd1, rnd2, rnd3, rnd4) = random_state
     rnd1 = [np.uint32(number) for number in rnd1]
     random_state = np.random.RandomState()
     random_state.set_state((rnd0, rnd1, rnd2, rnd3, rnd4))

--- a/tests/test_container_availbable.py
+++ b/tests/test_container_availbable.py
@@ -17,21 +17,25 @@ def search_container(container_name):
 
 def test_availability():
     container_names = ['pybnn',
+                       'paramnet',
                        'svm_benchmark',
                        'xgboost_benchmark',
                        'nasbench_101',
                        'nasbench_201',
+                       'nasbench_1shot1',
                        'tabular_benchmarks',
                        'cartpole',
                        'learna_benchmark'
                        ]
 
     all_available = True
+    not_available = []
     for container in container_names:
         container_available = search_container(container)
 
         if not container_available:
             logging.warning(f'Container for {container} is not found in {library}')
             all_available = False
+            not_available.append(container)
 
-    assert all_available, 'Some containers are not online available'
+    assert all_available, f'Some containers are not online available. {not_available}'

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -17,7 +17,7 @@ def test_nasbench_201_load_thread_safe():
 def test_nasbench_201_init():
 
     data_manager = NASBench_201Data(dataset='cifar100')
-    assert len(data_manager.files) == 4
+    assert len(data_manager.files) == 3
     assert all([file.startswith('NAS-Bench') for file in data_manager.files])
 
     with pytest.raises(AssertionError):
@@ -36,7 +36,7 @@ def test_nasbench_201_load():
 
     assert len(data) == 3
     assert (hpobench.config_file.data_dir / "nasbench_201").exists()
-    assert len(list((hpobench.config_file.data_dir / "nasbench_201").glob('*.json'))) == 4
+    assert len(list((hpobench.config_file.data_dir / "nasbench_201").glob('*.json'))) == 3
     assert not (hpobench.config_file.data_dir / "nasbench_201_data_v1.3.zip").exists()
 
     data_manager.data = None

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -14,26 +14,11 @@ def test_nasbench_201_load_thread_safe():
         pool.map(function, [])
 
 
-def test_nasbench_201_get_files():
-
-    files = NASBench_201Data.get_files_per_dataset(dataset='cifar10')
-    assert len(files) == 27
-    assert all([file.startswith('nb201_cifar10') for file in files])
-
-
-def test_nasbench_201_get_metrics():
-
-    metrics = NASBench_201Data.get_metrics()
-    assert metrics == ['train_acc1es', 'train_losses', 'train_times',
-                       'valid_acc1es', 'valid_times', 'valid_losses',
-                       'test_acc1es', 'test_times', 'test_losses']
-
-
 def test_nasbench_201_init():
 
     data_manager = NASBench_201Data(dataset='cifar100')
-    assert len(data_manager.files) == 27
-    assert all([file.startswith('nb201_cifar10') for file in data_manager.files])
+    assert len(data_manager.files) == 4
+    assert all([file.startswith('NAS-Bench') for file in data_manager.files])
 
     with pytest.raises(AssertionError):
         NASBench_201Data(dataset='Non_existing_dataset')
@@ -49,17 +34,16 @@ def test_nasbench_201_load():
     data_manager = NASBench_201Data(dataset='cifar100')
     data = data_manager.load()
 
-    assert len(data) == len(list(NASBench_201Data.get_seeds_metrics()))
-    assert len(data) == 3 * len(NASBench_201Data.get_metrics())
+    assert len(data) == 3
     assert (hpobench.config_file.data_dir / "nasbench_201").exists()
-    assert len(list((hpobench.config_file.data_dir / "nasbench_201").glob('*.pkl'))) == 108
-    assert not (hpobench.config_file.data_dir / "nasbench_201_data_v1.2.zip").exists()
+    assert len(list((hpobench.config_file.data_dir / "nasbench_201").glob('*.json'))) == 4
+    assert not (hpobench.config_file.data_dir / "nasbench_201_data_v1.3.zip").exists()
 
     data_manager.data = None
 
     data_manager = NASBench_201Data(dataset='cifar100')
     data = data_manager.load()
-    assert len(data) == 3 * len(NASBench_201Data.get_metrics())
+    assert len(data) == 3
 
 
 def test_year_prediction_msd_data():

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -5,8 +5,10 @@ import pytest
 
 import hpobench
 from hpobench.util.data_manager import NASBench_201Data, YearPredictionMSDData, ProteinStructureData, BostonHousingData
+skip_message = 'We currently skip this test because it takes too much time.'
 
 
+@pytest.mark.skip(reason=skip_message)
 def test_nasbench_201_load_thread_safe():
     shutil.rmtree(hpobench.config_file.data_dir / "nasbench_201", ignore_errors=True)
     function = lambda: NASBench_201Data(dataset='cifar100').load()
@@ -14,6 +16,7 @@ def test_nasbench_201_load_thread_safe():
         pool.map(function, [])
 
 
+@pytest.mark.skip(reason=skip_message)
 def test_nasbench_201_init():
 
     data_manager = NASBench_201Data(dataset='cifar100')
@@ -27,6 +30,7 @@ def test_nasbench_201_init():
     assert data_manager._save_dir.exists()
 
 
+@pytest.mark.skip(reason=skip_message)
 def test_nasbench_201_load():
 
     shutil.rmtree(hpobench.config_file.data_dir / "nasbench_201", ignore_errors=True)

--- a/tests/test_nasbench_201.py
+++ b/tests/test_nasbench_201.py
@@ -4,18 +4,18 @@ logging.basicConfig(level=logging.DEBUG)
 import pytest
 
 from hpobench.benchmarks.nas.nasbench_201 import ImageNetNasBench201Benchmark, Cifar100NasBench201Benchmark, \
-    Cifar10ValidNasBench201Benchmark, Cifar10NasBench201Benchmark
+    Cifar10ValidNasBench201Benchmark
 
 from hpobench.util.container_utils import disable_container_debug, enable_container_debug
 
 skip_message = 'We currently skip this test because it takes too much time.'
+
 
 @pytest.fixture(scope='module')
 def enable_debug():
     enable_container_debug()
     yield
     disable_container_debug()
-
 
 
 @pytest.mark.skip(reason=skip_message)
@@ -73,79 +73,15 @@ def test_nasbench201_Image(enable_debug):
     assert result['info']['train_cost'] == result['cost']
 
 
-@pytest.mark.skip(reason=skip_message)
-def test_nasbench201_cifar10_container(enable_debug):
-    b = Cifar10NasBench201Benchmark(rng=0)
-
-    cs = b.get_configuration_space(seed=0)
-    config = cs.sample_configuration()
-    fidelity = {'epoch': 199}
-
-    result = b.objective_function(configuration=config, fidelity=fidelity, data_seed=(777, 888, 999))
-
-    assert result is not None
-    assert result['function_value'] == pytest.approx(0.5019, abs=0.1)
-    assert result['cost'] == pytest.approx(13301.76, abs=0.1)
-    assert result['info']['train_precision'] == result['function_value']
-
-
-@pytest.mark.skip(reason=skip_message)
-def test_nasbench201_cifar10():
-    b = Cifar10NasBench201Benchmark(rng=0)
-
-    assert b.data is not None
-    assert len(b.get_meta_information()) == 2
-
-    cs = b.get_configuration_space(seed=0)
-    config = cs.sample_configuration()
-    fidelity = {'epoch': 199}
-
-    result = b.objective_function(configuration=config, fidelity=fidelity, data_seed=(777, 888, 999))
-
-    assert result is not None
-    assert result['function_value'] == pytest.approx(0.5019, abs=0.1)
-    assert result['cost'] == pytest.approx(13301.76, abs=0.1)
-    assert result['info']['train_precision'] == result['function_value']
-
-    result_test = b.objective_function_test(configuration=config)
-    assert result['info']['train_precision'] == result_test['info']['train_precision']
-    assert result['info']['train_cost'] == result_test['info']['train_cost']
-    assert result['info']['train_losses'] == result_test['info']['train_losses']
-    assert result['info']['eval_precision'] == result_test['info']['eval_precision']
-    assert result['info']['eval_losses'] == result_test['info']['eval_losses']
-    assert result['info']['eval_cost'] == result_test['info']['eval_cost']
-
-    assert result_test['cost'] > result['cost']
-
-    result_lower = b.objective_function(configuration=config, fidelity={'epoch': 100},
-                                        data_seed=(777, 888, 999))
-    assert result['cost'] > result_lower['cost']
-
-    with pytest.raises(ValueError):
-        b.objective_function(configuration=config, fidelity={'epoch': 200}, data_seed=0.1)
-
-    with pytest.raises(AssertionError):
-        b.objective_function(configuration=config, fidelity=fidelity, data_seed=0.1)
-
-    with pytest.raises(AssertionError):
-        b.objective_function(configuration=config, fidelity=fidelity, data_seed=0)
-
-    with pytest.raises(AssertionError):
-        b.objective_function(configuration=config, fidelity=fidelity, data_seed=[777, 881])
-
-    with pytest.raises(AssertionError):
-        b.objective_function(configuration=config, fidelity=fidelity, data_seed=(777, 881))
-
-
 def test_nasbench201_fidelity_space():
-    fs = Cifar10NasBench201Benchmark.get_fidelity_space()
+    fs = Cifar10ValidNasBench201Benchmark.get_fidelity_space()
     assert len(fs.get_hyperparameters()) == 1
 
 
 def test_nasbench201_config():
-    cs = Cifar10NasBench201Benchmark.get_configuration_space(seed=0)
+    cs = Cifar10ValidNasBench201Benchmark.get_configuration_space(seed=0)
     c = cs.sample_configuration()
-    func = Cifar10NasBench201Benchmark.config_to_structure_func(4)
+    func = Cifar10ValidNasBench201Benchmark.config_to_structure_func(4)
     struct = func(c)
 
     assert struct.__repr__() == '_Structure(4 nodes with |avg_pool_3x3~0|+|none~0|nor_conv_3x3~1|+' \

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -11,12 +11,12 @@ def set_log_level(debug):
 
 def test_debug_env_variable_1():
     set_log_level(False)
-    from hpobench.container.client_abstract_benchmark import log_level
-    assert log_level == logging.INFO
+    from hpobench.container.client_abstract_benchmark import LOG_LEVEL
+    assert LOG_LEVEL == logging.INFO
 
     set_log_level(True)
-    from hpobench.container.client_abstract_benchmark import log_level
-    assert log_level == logging.DEBUG
+    from hpobench.container.client_abstract_benchmark import LOG_LEVEL
+    assert LOG_LEVEL == logging.DEBUG
 
 
 def test_debug_container():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -36,29 +36,3 @@ def test_debug_container():
     assert cs is not None
 
     set_log_level(False)
-
-
-def test_benchmark_encoder():
-    from enum import Enum
-    class test_enum(Enum):
-        obj = 'name'
-
-        def __str__(self):
-            return str(self.value)
-
-    from hpobench.container.server_abstract_benchmark import BenchmarkEncoder
-    import json
-    import numpy as np
-
-    enum_obj = test_enum.obj
-    enum_obj_str = json.dumps(enum_obj, cls=BenchmarkEncoder)
-    assert enum_obj_str == '"name"'
-
-    array = np.array([1, 2, 3, 4])
-    array_str = json.dumps(array, cls=BenchmarkEncoder)
-    assert array_str == '[1, 2, 3, 4]'
-
-
-if __name__ == '__main__':
-    test_debug_env_variable_1()
-    test_debug_container()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -77,6 +77,27 @@ def test_rng_serialization_xgb():
     assert np.array_equiv(meta['initial random seed'].random(10), meta_new['initial random seed'].random(10))
 
 
+def test_benchmark_encoder():
+    from enum import Enum
+    class test_enum(Enum):
+        obj = 'name'
+
+        def __str__(self):
+            return str(self.value)
+
+    from hpobench.util.container_utils import BenchmarkEncoder, BenchmarkDecoder
+    import json
+    import numpy as np
+
+    enum_obj = test_enum.obj
+    enum_obj_str = json.dumps(enum_obj, cls=BenchmarkEncoder)
+    assert enum_obj_str == '"name"'
+
+    array = np.array([1, 2, 3, 4])
+    array_str = json.dumps(array, cls=BenchmarkEncoder)
+    array_ = json.loads(array_str, cls=BenchmarkDecoder)
+    assert np.array_equiv(array, array_)
+
 def test_debug_level():
     from hpobench.util.container_utils import enable_container_debug, disable_container_debug
     import os


### PR DESCRIPTION
Hey, this one is a large one.

This benchmark tackles the following problems:

- closes #50, closes #74: To be able to return the used seed and further information in the `get_meta_information()` of the SVM and XGB Benchmark, I had to rewrite to some degree the client-server-logic. Since I had to change it, I used this chance to make some further major updates. Now, you can query the `get_meta_information()`of the mentioned benchmarks to get information about the split size, the used seed, and so on. 
- closes #35, closes #45, closes #46, closes #49, closes #55: This pull request also simplifies some logic in the wrapper and removes some old code, such as the support for configurations as lists and arrays. I have also implemented a robust JSON Decoder and Encoder to handle more types of data, which is sent between the container and client. 
- Furthermore, we use now the pylint package to ensure that there is no API inconsistency between the derived and the base classes. If a class has for example an additional input parameter, the developer has to label this line of code so that pylint ignores this inconsistency. But with that, we can ensure that the developer has to know what he is doing and he has to take care of it. 
- The new wrapper converts the given configuration and fidelity-configuration to dictionary before it is sent to the benchmark. 
- closes #72: Nas1shot1 as well as Nasbench101 works now with run_indices. 
- Nasbench201 operates on the newly extracted data (saved as json). We refer to this data as version 1.3. I have updated the docstrings accordingly. The docstring contains now a detailed explanation of the splits as well as the incumbent performances. 
- The configfile is based on yaml instead of configparser. This allows the user to make comments. The code is more simplified and better to maintain.
- The configFile supports some kind of version watcher. If the configfile was created with an older version of the hpobench, than the current version, a warning is raised. Furthermore, the log level can be set via the configFile. 

- A lot of simplifications, codestyle improvements, ...


I am currently uploading the container. So, at the moment, the tests will fail. I will inform you when it is done. 
