### PR TITLE
Improve __del__ 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,17 @@
 # 0.0.7
-
+  * Fix an error in the NASBench1shot1 Benchmark (SearchSpace3).
+  * Improve the behavior when a benchmark container is shut down.
+  
 # 0.0.6
   * Add NasBench1shot1 Benchmark
   * Add info about incumbents for nasbench201 to its docstrings. 
+  * XGB and SVM's `get_meta_information()`-function returns now information about the used data set split.
+  * Simplify the wrapper. Remove the support for configurations as lists and arrays. 
+  * Enforce the correct class-interfaces with the pylint package. To deviate from the standard interface,
+  you have to explicitly deactivate the pylint error. 
+  * Nas1shot1 and Nas101 take as as input parameter now a seed.
+  * The config file is now based on yaml. Also, it automatically raises a warning if the configuration file-version 
+  does not match the HPOBench-version.
     
 # 0.0.5
   * Rename package to HPOBench


### PR DESCRIPTION
The __del__ method did often raise some PyroConnection Errors. 

Those happened when the container was already deleted and only the Proxy object was there. 