### PR TITLE
Improve the configuration version checking

### DIFF
--- a/tests/test_hpobenchconfig.py
+++ b/tests/test_hpobenchconfig.py
@@ -1,0 +1,19 @@
+
+def test_version_check():
+    from hpobench.config import HPOBenchConfig
+
+    # Same partition
+    assert HPOBenchConfig._check_version('0.0.0', '0.0.1')
+    assert HPOBenchConfig._check_version('0.0.0', '0.0.5')
+
+    assert HPOBenchConfig._check_version('0.0.6', '0.0.7')
+    assert HPOBenchConfig._check_version('0.0.7', '0.0.1234')
+    assert HPOBenchConfig._check_version('1.0.0', '0.0.6')
+
+    assert not HPOBenchConfig._check_version(None, '0.0.1')
+    assert not HPOBenchConfig._check_version(None, '0.0.6')
+    assert not HPOBenchConfig._check_version('0.0.5', '0.0.6')
+
+
+if __name__ == '__main__':
+    test_version_check()


### PR DESCRIPTION
The hpobench threw often an error, because the config file version was not exactly the same as the version number of a container. We now have relaxed the equality condition. We simply check if the version is in a equivalent partition.
A partition is defined by the change of the configuration file. Every time the code of the configuration file changes, a new partition should be created.