### PR TITLE
XGBoost Version 0.0.2: New Search Space + Larger Search Space. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Run a random configuration within a singularity container
 from hpobench.container.benchmarks.ml.xgboost_benchmark import XGBoostBenchmark
 b = XGBoostBenchmark(task_id=167149, container_source='library://phmueller/automl', rng=1)
 config = b.get_configuration_space(seed=1).sample_configuration()
-result_dict = b.objective_function(configuration=config, fidelity={"n_estimators": 128, "subsample": 0.5}, rng=1)
+result_dict = b.objective_function(configuration=config, fidelity={"n_estimators": 128, "dataset_fraction": 0.5}, rng=1)
 ```
 
 All benchmarks can also be queried with fewer or no fidelities:
@@ -39,7 +39,7 @@ A simple example is the XGBoost benchmark which can be installed with `pip insta
 from hpobench.benchmarks.ml.xgboost_benchmark import XGBoostBenchmark
 b = XGBoostBenchmark(task_id=167149)
 config = b.get_configuration_space(seed=1).sample_configuration()
-result_dict = b.objective_function(configuration=config, fidelity={"n_estimators": 128, "subsample": 0.5}, rng=1)
+result_dict = b.objective_function(configuration=config, fidelity={"n_estimators": 128, "dataset_fraction": 0.5}, rng=1)
 
 ```
 
@@ -60,6 +60,7 @@ pip install .
 | Benchmark Name                    | Container Name     | Container Source                     | Hosted at | Additional Info                      |
 | :-------------------------------- | ------------------ | ------------------------------------ | ----------|-------------------------------------- |
 | XGBoostBenchmark                  | xgboost_benchmark  | library://phmueller/automl/xgboost_benchmark | [Sylabs](https://cloud.sylabs.io/library/phmueller/automl) | Works with OpenML task ids |
+| XGBoostBoosterBenchmark           | xgboost_benchmark  | library://phmueller/automl/xgboost_benchmark | [Sylabs](https://cloud.sylabs.io/library/phmueller/automl) | Works with OpenML task ids + Contains Additional Parameter `Booster |
 | SupportVectorMachine              | svm_benchmark      | library://phmueller/automl/svm_benchmark | [Sylabs](https://cloud.sylabs.io/library/phmueller/automl) | Works with OpenML task ids |
 | BNNOnToyFunction                  | pybnn              | library://phmueller/automl/pybnn     | [Sylabs](https://cloud.sylabs.io/library/phmueller/automl) |  |
 | BNNOnBostonHousing                | pybnn              | library://phmueller/automl/pybnn     | [Sylabs](https://cloud.sylabs.io/library/phmueller/automl) |  |
@@ -129,7 +130,7 @@ from hpobench.container.benchmarks.ml.xgboost_benchmark import XGBoostBenchmark
 b = XGBoostBenchmark(task_id=167149, container_name="xgboost_benchmark", 
                      container_source='./') # path to hpobench/container/recipes/ml
 config = b.get_configuration_space(seed=1).sample_configuration()
-result_dict = b.objective_function(config, fidelity={"n_estimators": 128, "subsample": 0.5})
+result_dict = b.objective_function(config, fidelity={"n_estimators": 128, "dataset_fraction": 0.5})
 ```
 
 ### Remove all caches

--- a/hpobench/benchmarks/ml/xgboost_benchmark.py
+++ b/hpobench/benchmarks/ml/xgboost_benchmark.py
@@ -2,7 +2,6 @@
 
 Changelog:
 ==========
-
 0.0.2:
 * Change the search space definiton to match the paper: (https://arxiv.org/pdf/1802.09596.pdf)
     eta:                [1e-5, 1] (def: 0.3)    ->  [2**-10, 1] (def: 0.3)
@@ -13,12 +12,14 @@ Changelog:
     reg_alpha:          [1e-5, 2] (def: 1e-5)   ->  [2**-10, 2**10] (def: 1)
     max_depth:          -                       ->  [1, 15] (def: 6)
     subsample_per_it:   -                       ->  [0.01, 1] (def: 1)
-    [booster:            -                       ->  [gbtree, gblinear, dart] (def: gbtree)] *)
+    [booster:            -                      ->  [gbtree, gblinear, dart] (def: gbtree)]  *)
 
     *) This parameter is only in the XGBoostBoosterBenchmark. Not in the XGBoostBenchmark class.
 
+* Increase the fidelity `n_estimators`
+    n_estimators        [2, 128] (def: 128)     ->  [1, 256] (def: 256)
 
-* Add class to optimize booster method: (gbtree, gblinear or dart)
+* Add class to optimize also the used booster method: (gbtree, gblinear or dart)
     We have introduced a new class, which adds the used booster as parameter to the configuration space. To read more
     about booster, please take a look in the official XGBoost-documentation (https://xgboost.readthedocs.io/en/latest).
 
@@ -273,7 +274,7 @@ class XGBoostBenchmark(AbstractBenchmark):
             CS.UniformFloatHyperparameter('colsample_bylevel', lower=0.01, upper=1., default_value=1.),
             CS.UniformFloatHyperparameter('reg_lambda', lower=2**-10, upper=2**10, default_value=1, log=True),
             CS.UniformFloatHyperparameter('reg_alpha', lower=2**-10, upper=2**10, default_value=1, log=True),
-            CS.UniformFloatHyperparameter('subsample_per_it', lower=0.01, upper=1, default_value=1, log=False)
+            CS.UniformFloatHyperparameter('subsample_per_it', lower=0.1, upper=1, default_value=1, log=False)
         ])
 
         return cs

--- a/hpobench/benchmarks/ml/xgboost_benchmark.py
+++ b/hpobench/benchmarks/ml/xgboost_benchmark.py
@@ -4,14 +4,24 @@ Changelog:
 ==========
 
 0.0.2:
-* Changed the search space definiton to match the paper: (https://arxiv.org/pdf/1802.09596.pdf)
+* Change the search space definiton to match the paper: (https://arxiv.org/pdf/1802.09596.pdf)
     eta:                [1e-5, 1] (def: 0.3)    ->  [2**-10, 1] (def: 0.3)
     min_child_weight:   [0,05, 10] (def: 1)     ->  [1, 2**7] (def: 1)
-    colsample_bytree:   [0,05, 1] (def: 1)      ->  [0.05, 1] (def: 1)
-    colsample_bylevel:  [0,05, 1] (def: 1)      ->  [0.05, 1] (def: 1)
+    colsample_bytree:   [0,05, 1] (def: 1)      ->  [0.01, 1] (def: 1)
+    colsample_bylevel:  [0,05, 1] (def: 1)      ->  [0.01, 1] (def: 1)
     reg_lambda:         [1e-5, 2] (def: 1)      ->  [2**-10, 2**10] (def: 1)
     reg_alpha:          [1e-5, 2] (def: 1e-5)   ->  [2**-10, 2**10] (def: 1)
     max_depth:          -                       ->  [1, 15] (def: 6)
+    subsample_per_it:   -                       ->  [0.01, 1] (def: 1)
+    [booster:            -                       ->  [gbtree, gblinear, dart] (def: gbtree)] *)
+
+    *) This parameter is only in the XGBoostBoosterBenchmark. Not in the XGBoostBenchmark class.
+
+
+* Add class to optimize booster method: (gbtree, gblinear or dart)
+    We have introduced a new class, which adds the used booster as parameter to the configuration space. To read more
+    about booster, please take a look in the official XGBoost-documentation (https://xgboost.readthedocs.io/en/latest).
+
 
 0.0.1:
 * First implementation of a XGBoost Benchmark.
@@ -259,10 +269,11 @@ class XGBoostBenchmark(AbstractBenchmark):
             CS.UniformFloatHyperparameter('eta', lower=2**-10, upper=1., default_value=0.3, log=True),
             CS.UniformIntegerHyperparameter('max_depth', lower=1, upper=15, default_value=6, log=False),
             CS.UniformFloatHyperparameter('min_child_weight', lower=1., upper=2**7., default_value=1., log=True),
-            CS.UniformFloatHyperparameter('colsample_bytree', lower=0.05, upper=1., default_value=1.),
-            CS.UniformFloatHyperparameter('colsample_bylevel', lower=0.05, upper=1., default_value=1.),
+            CS.UniformFloatHyperparameter('colsample_bytree', lower=0.01, upper=1., default_value=1.),
+            CS.UniformFloatHyperparameter('colsample_bylevel', lower=0.01, upper=1., default_value=1.),
             CS.UniformFloatHyperparameter('reg_lambda', lower=2**-10, upper=2**10, default_value=1, log=True),
-            CS.UniformFloatHyperparameter('reg_alpha', lower=2**-10, upper=2**10, default_value=1, log=True)
+            CS.UniformFloatHyperparameter('reg_alpha', lower=2**-10, upper=2**10, default_value=1, log=True),
+            CS.UniformFloatHyperparameter('subsample_per_it', lower=0.01, upper=1, default_value=1, log=False)
         ])
 
         return cs
@@ -287,7 +298,7 @@ class XGBoostBenchmark(AbstractBenchmark):
 
         fidel_space.add_hyperparameters([
             CS.UniformFloatHyperparameter("dataset_fraction", lower=0.0, upper=1.0, default_value=1.0, log=False),
-            CS.UniformIntegerHyperparameter("n_estimators", lower=2, upper=128, default_value=128, log=False)
+            CS.UniformIntegerHyperparameter("n_estimators", lower=1, upper=256, default_value=256, log=False)
         ])
 
         return fidel_space
@@ -311,8 +322,9 @@ class XGBoostBenchmark(AbstractBenchmark):
                 'task_id': self.task_id
                 }
 
-    def _get_pipeline(self, max_depth: int, eta: float, min_child_weight: int, colsample_bytree: float,
-                      colsample_bylevel: float, reg_lambda: int, reg_alpha: int, n_estimators: int) \
+    def _get_pipeline(self, max_depth: int, eta: float, min_child_weight: int,
+                      colsample_bytree: float, colsample_bylevel: float, reg_lambda: int, reg_alpha: int,
+                      n_estimators: int, subsample_per_it: float) \
             -> pipeline.Pipeline:
         """ Create the scikit-learn (training-)pipeline """
         objective = 'binary:logistic' if self.num_class <= 2 else 'multi:softmax'
@@ -339,6 +351,69 @@ class XGBoostBenchmark(AbstractBenchmark):
                  objective=objective,
                  n_jobs=self.n_threads,
                  random_state=self.rng.randint(1, 100000),
-                 num_class=self.num_class))
+                 num_class=self.num_class,
+                 subsample=subsample_per_it))
             ])
+        return clf
+
+
+class XGBoostBoosterBenchmark(XGBoostBenchmark):
+    """
+    Similar to XGBoostBenchmark but enables also the optimization of the used booster.
+    """
+
+    def __init__(self, task_id: Union[int, None] = None, n_threads: int = 1,
+                 rng: Union[np.random.RandomState, int, None] = None):
+        super(XGBoostBoosterBenchmark, self).__init__(task_id=task_id, n_threads=n_threads, rng=rng)
+
+    @staticmethod
+    def get_configuration_space(seed: Union[int, None] = None) -> CS.ConfigurationSpace:
+        cs = XGBoostBenchmark.get_configuration_space(seed)
+
+        cs.add_hyperparameter(CS.CategoricalHyperparameter('booster', choices=['gbtree', 'gblinear', 'dart'],
+                                                           default_value='gbtree'))
+        return cs
+
+    # noinspection PyMethodOverriding
+    # pylint: disable=arguments-differ
+    def _get_pipeline(self, booster: str, max_depth: int, eta: float, min_child_weight: int,
+                      colsample_bytree: float, colsample_bylevel: float, reg_lambda: int, reg_alpha: int,
+                      n_estimators: int, subsample_per_it: float) \
+            -> pipeline.Pipeline:
+        """ Create the scikit-learn (training-)pipeline """
+        objective = 'binary:logistic' if self.num_class <= 2 else 'multi:softmax'
+
+        configuration = dict(booster=booster,
+                             max_depth=max_depth,
+                             learning_rate=eta,
+                             min_child_weight=min_child_weight,
+                             colsample_bytree=colsample_bytree,
+                             colsample_bylevel=colsample_bylevel,
+                             reg_alpha=reg_alpha,
+                             reg_lambda=reg_lambda,
+                             n_estimators=n_estimators,
+                             objective=objective,
+                             n_jobs=self.n_threads,
+                             random_state=self.rng.randint(1, 100000),
+                             num_class=self.num_class,
+                             subsample=subsample_per_it)
+
+        # Some booster methods dont support all parameter. Delete them from the configuration to remove a xgb-warning.
+        if booster == 'gblinear':
+            for unused in ['colsample_bylevel', 'colsample_bytree', 'max_depth', 'min_child_weight', 'subsample']:
+                del configuration[unused]
+
+        print('test')
+        clf = pipeline.Pipeline([
+            ('preprocess_impute',
+             ColumnTransformer([
+                 ("categorical", "passthrough", self.categorical_data),
+                 ("continuous", SimpleImputer(strategy="mean"), ~self.categorical_data)])),
+            ('preprocess_one_hot',
+             ColumnTransformer([
+                 ("categorical", OneHotEncoder(categories=self.categories, sparse=False), self.categorical_data),
+                 ("continuous", "passthrough", ~self.categorical_data)])),
+            ('xgb',
+             xgb.XGBClassifier(**configuration))
+        ])
         return clf

--- a/hpobench/container/benchmarks/ml/xgboost_benchmark.py
+++ b/hpobench/container/benchmarks/ml/xgboost_benchmark.py
@@ -12,3 +12,11 @@ class XGBoostBenchmark(AbstractBenchmarkClient):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'XGBoostBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'xgboost_benchmark')
         super(XGBoostBenchmark, self).__init__(**kwargs)
+
+
+class XGBoostBoosterBenchmark(AbstractBenchmarkClient):
+    def __init__(self, task_id: int, **kwargs):
+        kwargs['task_id'] = task_id
+        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'XGBoostBoosterBenchmark')
+        kwargs['container_name'] = kwargs.get('container_name', 'xgboost_benchmark')
+        super(XGBoostBoosterBenchmark, self).__init__(**kwargs)


### PR DESCRIPTION
* Change the search space definiton to match the paper: (https://arxiv.org/pdf/1802.09596.pdf)
    eta:                           [1e-5, 1] (def: 0.3)    ->  [2**-10, 1] (def: 0.3)
    min_child_weight:     [0,05, 10] (def: 1)     ->  [1, 2**7] (def: 1)
    colsample_bytree:    [0,05, 1] (def: 1)        ->  [0.01, 1] (def: 1)
    colsample_bylevel:   [0,05, 1] (def: 1)        ->  [0.01, 1] (def: 1)
    reg_lambda:             [1e-5, 2] (def: 1)        ->  [2**-10, 2**10] (def: 1)
    reg_alpha:                [1e-5, 2] (def: 1e-5)   ->  [2**-10, 2**10] (def: 1)
    max_depth:               -                       ->  [1, 15] (def: 6)
    subsample_per_it:    -                       ->  [0.01, 1] (def: 1)
    [booster:                    -                      ->  [gbtree, gblinear, dart] (def: gbtree)]  *)

    *) This parameter is only in the XGBoostBoosterBenchmark. Not in the XGBoostBenchmark class.

* Increase the fidelity `n_estimators`
    n_estimators        [2, 128] (def: 128)     ->  [1, 256] (def: 256)

* Add class to optimize also the used booster method: (gbtree, gblinear or dart)
    We have introduced a new class, which adds the used booster as parameter to the configuration space. To read more
    about booster, please take a look in the official XGBoost-documentation (https://xgboost.readthedocs.io/en/latest).
