### PR TITLE
Fix93: Improve Container Integration

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,14 @@
 # 0.0.8
-
+  * Improve container integration
+    The containers had some problems when the file system was read-only. In this case, the home directory, which contains the 
+    hpobenchrc file, was not mounted, so the init of the containers failed. To circumvent this problem, we make multiple
+    changes: 
+    - We introduce an option to mount additional folder. This might be helpful when working on a cluster were the home 
+      directory is not available in the computation process.
+    - We also change the configuration file. The container does not read the yaml file anymore. Instead we bind the 
+      cache dir, data dir and socket dir into the container and let the container use them directly. We also remove the 
+      global data directory and use only the data dir from now onwards.
+    
 # 0.0.7
   * Fix an error in the NASBench1shot1 Benchmark (SearchSpace3).
   * Improve the behavior when a benchmark container is shut down.
@@ -32,7 +41,6 @@
   * Nas1shot1 and Nas101 take as as input parameter now a seed.
   * The config file is now based on yaml. Also, it automatically raises a warning if the configuration file-version 
     does not match the HPOBench-version.
-
     
 # 0.0.5
   * Rename package to HPOBench

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
     The containers had some problems when the file system was read-only. In this case, the home directory, which contains the 
     hpobenchrc file, was not mounted, so the init of the containers failed. To circumvent this problem, we make multiple
     changes: 
-    - We introduce an option to mount additional folder. This might be helpful when working on a cluster were the home 
+    - We introduce an option to mount additional folder. This might be helpful when working on a cluster where the home 
       directory is not available in the computation process.
     - We also change the configuration file. The container does not read the yaml file anymore. Instead we bind the 
       cache dir, data dir and socket dir into the container and let the container use them directly. We also remove the 

--- a/hpobench/__init__.py
+++ b/hpobench/__init__.py
@@ -1,4 +1,11 @@
-__contact__ = "automl.org"
+import logging
+
+_default_log_format = '[%(levelname)s] %(name)s at %(asctime)s --- %(message)s'
+logging.basicConfig(format=_default_log_format, level=logging.WARNING)
+root_logger = logging.getLogger()
 
 from hpobench.__version__ import __version__  # noqa: F401
 from hpobench.config import config_file  # noqa: F401
+
+
+__contact__ = "automl.org"

--- a/hpobench/__init__.py
+++ b/hpobench/__init__.py
@@ -4,8 +4,7 @@ _default_log_format = '[%(levelname)s] %(name)s at %(asctime)s --- %(message)s'
 logging.basicConfig(format=_default_log_format, level=logging.WARNING)
 root_logger = logging.getLogger()
 
-from hpobench.__version__ import __version__  # noqa: F401
-from hpobench.config import config_file  # noqa: F401
-
+from hpobench.__version__ import __version__  # noqa: F401, E402
+from hpobench.config import config_file  # noqa: F401, E402
 
 __contact__ = "automl.org"

--- a/hpobench/benchmarks/ml/pybnn.py
+++ b/hpobench/benchmarks/ml/pybnn.py
@@ -10,6 +10,10 @@ you need to install the following packages besides installing the hpobench with
 
 Changelog:
 ==========
+0.0.3
+* New container release due to a general change in the communication between container and HPOBench.
+  Works with HPOBench >= v0.0.8
+
 0.0.2:
 * Standardize the structure of the meta information
 * The minimum number of burn in steps was allowed to be 0. But then Theano throws an RunTimeError. Limit the number of
@@ -47,7 +51,7 @@ from sgmcmc.bnn.model import BayesianNeuralNetwork  # noqa: E402
 from sgmcmc.bnn.lasagne_layers import AppendLayer  # noqa: E402
 
 
-__version__ = '0.0.2'
+__version__ = '0.0.3'
 logger = logging.getLogger('PyBnnBenchmark')
 
 

--- a/hpobench/benchmarks/ml/svm_benchmark.py
+++ b/hpobench/benchmarks/ml/svm_benchmark.py
@@ -2,6 +2,10 @@
 
 Changelog:
 ==========
+0.0.3
+* New container release due to a general change in the communication between container and HPOBench.
+  Works with HPOBench >= v0.0.8
+
 0.0.2:
 * Standardize the structure of the meta information
 
@@ -28,7 +32,7 @@ import hpobench.util.rng_helper as rng_helper
 from hpobench.abstract_benchmark import AbstractBenchmark
 from hpobench.util.openml_data_manager import OpenMLHoldoutDataManager
 
-__version__ = '0.0.2'
+__version__ = '0.0.3'
 
 logger = logging.getLogger('SVMBenchmark')
 

--- a/hpobench/benchmarks/ml/xgboost_benchmark.py
+++ b/hpobench/benchmarks/ml/xgboost_benchmark.py
@@ -2,6 +2,10 @@
 
 Changelog:
 ==========
+0.0.3
+* New container release due to a general change in the communication between container and HPOBench.
+  Works with HPOBench >= v0.0.8
+
 0.0.2:
 * Change the search space definiton to match the paper: (https://arxiv.org/pdf/1802.09596.pdf)
     eta:                [1e-5, 1] (def: 0.3)    ->  [2**-10, 1] (def: 0.3)
@@ -47,7 +51,7 @@ import hpobench.util.rng_helper as rng_helper
 from hpobench.abstract_benchmark import AbstractBenchmark
 from hpobench.util.openml_data_manager import OpenMLHoldoutDataManager
 
-__version__ = '0.0.2'
+__version__ = '0.0.3'
 
 logger = logging.getLogger('XGBBenchmark')
 

--- a/hpobench/benchmarks/nas/nasbench_101.py
+++ b/hpobench/benchmarks/nas/nasbench_101.py
@@ -42,6 +42,10 @@ Querying another epoch, e.g. 5, raises an assertion.
 
 Changelog:
 ==========
+0.0.4
+* New container release due to a general change in the communication between container and HPOBench.
+  Works with HPOBench >= v0.0.8
+
 0.0.3:
 * Standardize the structure of the meta information
 
@@ -73,7 +77,7 @@ import hpobench.util.rng_helper as rng_helper
 from hpobench.abstract_benchmark import AbstractBenchmark
 from hpobench.util.data_manager import NASBench_101DataManager
 
-__version__ = '0.0.3'
+__version__ = '0.0.4'
 logger = logging.getLogger('NasBench101')
 
 MAX_EDGES = 9

--- a/hpobench/benchmarks/nas/nasbench_1shot1.py
+++ b/hpobench/benchmarks/nas/nasbench_1shot1.py
@@ -46,6 +46,10 @@ export PATH=/Path/to/nasbench-1shot1:$PATH
 
 Changelog:
 ==========
+0.0.4
+* New container release due to a general change in the communication between container and HPOBench.
+  Works with HPOBench >= v0.0.8
+
 0.0.3:
 * Standardize the structure of the meta information
 
@@ -77,7 +81,7 @@ from nasbench_analysis.search_spaces.search_space_2 import SearchSpace2  # noqa
 from nasbench_analysis.search_spaces.search_space_3 import SearchSpace3  # noqa
 from nasbench_analysis.utils import INPUT, OUTPUT, CONV1X1, CONV3X3, MAXPOOL3X3  # noqa
 
-__version__ = '0.0.3'
+__version__ = '0.0.4'
 logger = logging.getLogger('NasBench1shot1')
 
 

--- a/hpobench/benchmarks/nas/nasbench_201.py
+++ b/hpobench/benchmarks/nas/nasbench_201.py
@@ -27,6 +27,10 @@ https://github.com/D-X-Y/AutoDL-Projects/blob/master/docs/NAS-Bench-201.md
 
 Changelog:
 ==========
+0.0.4
+* New container release due to a general change in the communication between container and HPOBench.
+  Works with HPOBench >= v0.0.8
+
 0.0.3:
 * Standardize the structure of the meta information
 
@@ -49,7 +53,7 @@ import hpobench.util.rng_helper as rng_helper
 from hpobench.abstract_benchmark import AbstractBenchmark
 from hpobench.util.data_manager import NASBench_201Data
 
-__version__ = '0.0.3'
+__version__ = '0.0.4'
 MAX_NODES = 4
 
 logger = logging.getLogger('NASBENCH201')

--- a/hpobench/benchmarks/nas/tabular_benchmarks.py
+++ b/hpobench/benchmarks/nas/tabular_benchmarks.py
@@ -30,6 +30,10 @@ python setup.py install
 
 Changelog:
 ==========
+0.0.4
+* New container release due to a general change in the communication between container and HPOBench.
+  Works with HPOBench >= v0.0.8
+
 0.0.3:
 * Standardize the structure of the meta information
 
@@ -53,7 +57,7 @@ from tabular_benchmarks.fcnet_benchmark import FCNetBenchmark
 import hpobench.util.rng_helper as rng_helper
 from hpobench.abstract_benchmark import AbstractBenchmark
 
-__version__ = '0.0.3'
+__version__ = '0.0.4'
 logger = logging.getLogger('TabularBenchmark')
 
 

--- a/hpobench/benchmarks/rl/cartpole.py
+++ b/hpobench/benchmarks/rl/cartpole.py
@@ -1,6 +1,10 @@
 """
 Changelog:
 ==========
+0.0.3
+* New container release due to a general change in the communication between container and HPOBench.
+  Works with HPOBench >= v0.0.8
+
 0.0.2:
 * Standardize the structure of the meta information
 * Suppress unnecessary tensorforce logging messages
@@ -26,7 +30,7 @@ from tensorforce.execution import Runner  # noqa: E402
 from hpobench.abstract_benchmark import AbstractBenchmark  # noqa: E402
 from hpobench.util import rng_helper  # noqa: E402
 
-__version__ = '0.0.2'
+__version__ = '0.0.3'
 
 logger = logging.getLogger('CartpoleBenchmark')
 tf.logging.set_verbosity(tf.logging.ERROR)

--- a/hpobench/benchmarks/rl/learna_benchmark.py
+++ b/hpobench/benchmarks/rl/learna_benchmark.py
@@ -49,6 +49,10 @@ python -m python -m learna.data.download_and_build_eterna ./learna/data/secondar
 
 Changelog:
 ==========
+0.0.4
+* New container release due to a general change in the communication between container and HPOBench.
+  Works with HPOBench >= v0.0.8
+
 0.0.3:
 * Standardize the structure of the meta information
 
@@ -76,7 +80,7 @@ import hpobench.config
 from hpobench.abstract_benchmark import AbstractBenchmark
 from hpobench.util import rng_helper
 
-__version__ = '0.0.3'
+__version__ = '0.0.4'
 
 logger = logging.getLogger('LearnaBenchmark')
 

--- a/hpobench/benchmarks/surrogates/paramnet_benchmark.py
+++ b/hpobench/benchmarks/surrogates/paramnet_benchmark.py
@@ -47,9 +47,13 @@ pip install .[paramnet]
 
 Changelog:
 ==========
-0.0.3
+0.0.4
 * New container release due to a general change in the communication between container and HPOBench.
   Works with HPOBench >= v0.0.8
+
+0.0.3:
+* Fix returned dictionary from Objective Function for ParamNetOnTime Benchmarks.
+* Suppress Warning (Surrogate was created with scikit-learn version 0.18.1 and current is 0.23.2)
 
 0.0.2:
 * Fix OnTime Test function:

--- a/hpobench/benchmarks/surrogates/paramnet_benchmark.py
+++ b/hpobench/benchmarks/surrogates/paramnet_benchmark.py
@@ -47,6 +47,10 @@ pip install .[paramnet]
 
 Changelog:
 ==========
+0.0.3
+* New container release due to a general change in the communication between container and HPOBench.
+  Works with HPOBench >= v0.0.8
+
 0.0.2:
 * Fix OnTime Test function:
   The `objective_test_function` of the OnTime Benchmarks now checks if the budget is the right maximum budget.
@@ -65,7 +69,7 @@ import numpy as np
 from hpobench.abstract_benchmark import AbstractBenchmark
 from hpobench.util.data_manager import ParamNetDataManager
 
-__version__ = '0.0.2'
+__version__ = '0.0.3'
 
 logger = logging.getLogger('Paramnet')
 

--- a/hpobench/config.py
+++ b/hpobench/config.py
@@ -39,27 +39,29 @@ class HPOBenchConfig:
         # Constant paths in the container
         self._cache_dir_container = '/var/lib/hpobench/cache'
         self._data_dir_container = '/var/lib/hpobench/data'
-        self._socket_dir_container = '/tmp/hpobench_socket/'
+        self._socket_dir_container = '/var/lib/socket'
 
         # According to https://github.com/openml/openml-python/issues/884, try to set default directories.
         self.config_base_dir = Path(os.environ.get('XDG_CONFIG_HOME', '~/.config/hpobench')).expanduser().absolute()
 
         # The path to the hpobenchrc file. This file stores the settings defined by the user
-        self.config_file = (self.config_base_dir / '.hpobenchrc').expanduser().absolute()
+        self.config_file = (self.config_base_dir / '.hpobenchrc')
 
         # The cache dir contains the lock files, etc.
         if not self._is_container:
             self.cache_dir = os.environ.get('XDG_CACHE_HOME', '~/.cache/hpobench')
             self.data_dir = os.environ.get('XDG_DATA_HOME', '~/.local/share/hpobench')
+            self.socket_dir = os.environ.get('TMPDIR', '/tmp/hpobench_socket/')
         else:
             self.cache_dir = self._cache_dir_container
             self.data_dir = self._data_dir_container
+            self.socket_dir = self._socket_dir_container
 
         self.cache_dir = Path(self.cache_dir).expanduser().absolute()
         self.data_dir = Path(self.data_dir).expanduser().absolute()
 
         # Options for the singularity container
-        self.socket_dir = Path('/tmp/hpobench_socket/')
+        self.socket_dir = Path(self.socket_dir).expanduser().absolute()
         self.container_dir = self.cache_dir / f'hpobench-{os.getuid()}'
         self.container_source = 'oras://gitlab.tf.uni-freiburg.de:5050/muelleph/hpobench-registry'
         self.pyro_connect_max_wait = 400

--- a/hpobench/config.py
+++ b/hpobench/config.py
@@ -7,6 +7,8 @@ from yaml.parser import ParserError
 
 from hpobench import __version__
 
+root_logger = logging.getLogger()
+
 
 class HPOBenchConfig:
 
@@ -185,9 +187,9 @@ class HPOBenchConfig:
 
         if mismatch:
             config_version = config_version if not None else 'None'
-            logging.warning(f'The hpobenchrc file was created with another version of the hpobench. '
-                            f'Current version of the hpobenchrc file: {config_version}.\n'
-                            f'Current version of the hpobench: {hpobench_version}')
+            root_logger.warning(f'The hpobenchrc file was created with another version of the hpobench. '
+                                f'Current version of the hpobenchrc file: {config_version}.\n'
+                                f'Current version of the hpobench: {hpobench_version}')
 
         return not mismatch
 

--- a/hpobench/config.py
+++ b/hpobench/config.py
@@ -1,4 +1,3 @@
-import ast
 import logging
 import os
 from pathlib import Path
@@ -23,13 +22,6 @@ class HPOBenchConfig:
         """
         self.logger = logging.getLogger('HPOBenchConfig')
 
-        # According to https://github.com/openml/openml-python/issues/884, try to set default directories.
-        self.config_base_dir = Path(os.environ.get('XDG_CONFIG_HOME', '~/.config/hpobench')).expanduser()
-
-        # The path to the hpobenchrc file
-        self.config_file = self.config_base_dir / '.hpobenchrc'
-        self.config_file = self.config_file.expanduser().absolute()
-
         # The configuration file should have the same version as the hpobench. Raise a warning if there is a version
         # mismatch. We want to make sure that the configuration file is up to date with the hpobench, because it is
         # possible that something in the configuration has changed but the old hpobenchrc file is still there and
@@ -41,18 +33,33 @@ class HPOBenchConfig:
         # See also https://docs.python.org/3/library/logging.html#logging-levels
         self.verbosity = 0
 
-        # The cache dir contains the lock files etc
-        self.cache_dir = Path(os.environ.get('XDG_CACHE_HOME', '~/.cache/hpobench')).expanduser()
+        # Test if the configuration is created from inside a container
+        self._is_container = os.environ.get('SINGULARITY_NAME') is not None and os.environ.get('SINGULARITY_NAME') != ''
 
-        # The user can specify if the local or a more global data directory should be used. This is helpful when working
-        # on a cluster
-        self.data_dir = self.config_base_dir
-        self.global_data_dir = Path(os.environ.get('XDG_DATA_HOME', '~/.local/share/hpobench')).expanduser()
-        self.use_global_data = True
+        # Constant paths in the container
+        self._cache_dir_container = '/var/lib/hpobench/cache'
+        self._data_dir_container = '/var/lib/hpobench/data'
+        self._socket_dir_container = '/tmp/hpobench_socket/'
+
+        # According to https://github.com/openml/openml-python/issues/884, try to set default directories.
+        self.config_base_dir = Path(os.environ.get('XDG_CONFIG_HOME', '~/.config/hpobench')).expanduser().absolute()
+
+        # The path to the hpobenchrc file. This file stores the settings defined by the user
+        self.config_file = (self.config_base_dir / '.hpobenchrc').expanduser().absolute()
+
+        # The cache dir contains the lock files, etc.
+        if not self._is_container:
+            self.cache_dir = os.environ.get('XDG_CACHE_HOME', '~/.cache/hpobench')
+            self.data_dir = os.environ.get('XDG_DATA_HOME', '~/.local/share/hpobench')
+        else:
+            self.cache_dir = self._cache_dir_container
+            self.data_dir = self._data_dir_container
+
+        self.cache_dir = Path(self.cache_dir).expanduser().absolute()
+        self.data_dir = Path(self.data_dir).expanduser().absolute()
 
         # Options for the singularity container
-        # Find all hosted container on: https://cloud.sylabs.io/library/phmueller/automl
-        self.socket_dir = Path('/tmp')
+        self.socket_dir = Path('/tmp/hpobench_socket/')
         self.container_dir = self.cache_dir / f'hpobench-{os.getuid()}'
         self.container_source = 'oras://gitlab.tf.uni-freiburg.de:5050/muelleph/hpobench-registry'
         self.pyro_connect_max_wait = 400
@@ -65,23 +72,18 @@ class HPOBenchConfig:
 
         Parameters:
         -----------
-
-        config_file: Path, str
-            Path to config file
+        is_container: bool
         """
+        if not self._is_container:
+            # Create an empty config file if there was none so far
+            if not self.config_file.exists():
+                self.__create_config_file()
 
-        # Create an empty config file if there was none so far
-        if not self.config_file.exists():
-            self.__create_config_file()
+            self.__parse_config()
+            self.__check_dir(self.container_dir)
 
-        # Parse config
-        self.__parse_config()
-
-        # Check whether data_dir exists, if not create it
-        self.__check_dir(self.data_dir)
-        self.__check_dir(self.global_data_dir)
         self.__check_dir(self.socket_dir)
-        self.__check_dir(self.container_dir)
+        self.__check_dir(self.data_dir)
         self.__check_dir(self.cache_dir)
 
     def __create_config_file(self):
@@ -93,8 +95,6 @@ class HPOBenchConfig:
                     'verbosity': self.verbosity,
                     'cache_dir': str(self.cache_dir),
                     'data_dir': str(self.data_dir),
-                    'global_data_dir': str(self.global_data_dir),
-                    'use_global_data': True,
                     'socket_dir': str(self.socket_dir),
                     'container_dir': str(self.container_dir),
                     'container_source': self.container_source,
@@ -127,22 +127,12 @@ class HPOBenchConfig:
         # logging.basicConfig(level=self.verbosity)  # TODO: This statement causes some trouble.
         #                                                    (Container-Logger is always set to debug)
 
-        self.cache_dir = Path(read_config.get('cache_dir', self.cache_dir))
-        self.data_dir = Path(read_config.get('data_dir', self.data_dir))
-        self.global_data_dir = Path(read_config.get('global_data_dir', self.global_data_dir))
-        self.use_global_data = read_config.get('use_global_data', self.use_global_data)
-
-        if isinstance(self.use_global_data, str):
-            self.use_global_data = ast.literal_eval(self.use_global_data)
-
-        if self.global_data_dir.is_dir() and self.use_global_data:
-            self.data_dir = self.global_data_dir
-
-        self.socket_dir = Path(read_config.get('socket_dir', self.socket_dir))
-        self.container_dir = Path(read_config.get('container_dir', self.container_dir))
+        self.cache_dir = Path(read_config.get('cache_dir', self.cache_dir)).expanduser().absolute()
+        self.data_dir = Path(read_config.get('data_dir', self.data_dir)).expanduser().absolute()
+        self.socket_dir = Path(read_config.get('socket_dir', self.socket_dir)).expanduser().absolute()
+        self.container_dir = Path(read_config.get('container_dir', self.container_dir)).expanduser().absolute()
         self.container_source = read_config.get('container_source', self.container_source)
-        self.pyro_connect_max_wait = int(read_config.get('pyro_connect_max_wait',
-                                                         self.pyro_connect_max_wait))
+        self.pyro_connect_max_wait = int(read_config.get('pyro_connect_max_wait', self.pyro_connect_max_wait))
 
     @staticmethod
     def _check_version(config_version, hpobench_version):
@@ -201,11 +191,7 @@ class HPOBenchConfig:
 
     def __check_dir(self, path: Path):
         """ Check whether dir exists and if not create it"""
-        try:
-            Path(path).mkdir(exist_ok=True, parents=True)
-        except (IOError, OSError) as e:
-            self.logger.debug(f'Could not create directory here: {self.data_dir}')
-            raise e
+        Path(path).mkdir(exist_ok=True, parents=True)
 
 
 config_file = HPOBenchConfig()

--- a/hpobench/config.py
+++ b/hpobench/config.py
@@ -39,7 +39,7 @@ class HPOBenchConfig:
         # Constant paths in the container
         self._cache_dir_container = '/var/lib/hpobench/cache'
         self._data_dir_container = '/var/lib/hpobench/data'
-        self._socket_dir_container = '/var/lib/socket'
+        self._socket_dir_container = '/var/lib/hpobench/socket'
 
         # According to https://github.com/openml/openml-python/issues/884, try to set default directories.
         self.config_base_dir = Path(os.environ.get('XDG_CONFIG_HOME', '~/.config/hpobench')).expanduser().absolute()

--- a/hpobench/container/benchmarks/ml/pybnn.py
+++ b/hpobench/container/benchmarks/ml/pybnn.py
@@ -10,7 +10,7 @@ class BNNOnToyFunction(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'BNNOnToyFunction')
         kwargs['container_name'] = kwargs.get('container_name', 'pybnn')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(BNNOnToyFunction, self).__init__(**kwargs)
 
 
@@ -18,7 +18,7 @@ class BNNOnBostonHousing(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'BNNOnBostonHousing')
         kwargs['container_name'] = kwargs.get('container_name', 'pybnn')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(BNNOnBostonHousing, self).__init__(**kwargs)
 
 
@@ -26,7 +26,7 @@ class BNNOnProteinStructure(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'BNNOnProteinStructure')
         kwargs['container_name'] = kwargs.get('container_name', 'pybnn')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(BNNOnProteinStructure, self).__init__(**kwargs)
 
 
@@ -34,5 +34,5 @@ class BNNOnYearPrediction(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'BNNOnYearPrediction')
         kwargs['container_name'] = kwargs.get('container_name', 'pybnn')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(BNNOnYearPrediction, self).__init__(**kwargs)

--- a/hpobench/container/benchmarks/ml/svm_benchmark.py
+++ b/hpobench/container/benchmarks/ml/svm_benchmark.py
@@ -11,5 +11,5 @@ class SupportVectorMachine(AbstractBenchmarkClient):
         kwargs['task_id'] = task_id
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'SupportVectorMachine')
         kwargs['container_name'] = kwargs.get('container_name', 'svm_benchmark')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(SupportVectorMachine, self).__init__(**kwargs)

--- a/hpobench/container/benchmarks/ml/xgboost_benchmark.py
+++ b/hpobench/container/benchmarks/ml/xgboost_benchmark.py
@@ -11,7 +11,7 @@ class XGBoostBenchmark(AbstractBenchmarkClient):
         kwargs['task_id'] = task_id
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'XGBoostBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'xgboost_benchmark')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(XGBoostBenchmark, self).__init__(**kwargs)
 
 
@@ -20,5 +20,5 @@ class XGBoostExtendedBenchmark(AbstractBenchmarkClient):
         kwargs['task_id'] = task_id
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'XGBoostExtendedBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'xgboost_benchmark')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(XGBoostExtendedBenchmark, self).__init__(**kwargs)

--- a/hpobench/container/benchmarks/nas/nasbench_101.py
+++ b/hpobench/container/benchmarks/nas/nasbench_101.py
@@ -10,7 +10,7 @@ class NASCifar10ABenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'NASCifar10ABenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'nasbench_101')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(NASCifar10ABenchmark, self).__init__(**kwargs)
 
 
@@ -18,7 +18,7 @@ class NASCifar10BBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'NASCifar10BBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'nasbench_101')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(NASCifar10BBenchmark, self).__init__(**kwargs)
 
 
@@ -26,5 +26,5 @@ class NASCifar10CBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'NASCifar10CBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'nasbench_101')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(NASCifar10CBenchmark, self).__init__(**kwargs)

--- a/hpobench/container/benchmarks/nas/nasbench_1shot1.py
+++ b/hpobench/container/benchmarks/nas/nasbench_1shot1.py
@@ -10,7 +10,7 @@ class NASBench1shot1SearchSpace1Benchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'NASBench1shot1SearchSpace1Benchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'nasbench_1shot1')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(NASBench1shot1SearchSpace1Benchmark, self).__init__(**kwargs)
 
 
@@ -18,7 +18,7 @@ class NASBench1shot1SearchSpace2Benchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'NASBench1shot1SearchSpace2Benchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'nasbench_1shot1')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(NASBench1shot1SearchSpace2Benchmark, self).__init__(**kwargs)
 
 
@@ -26,5 +26,5 @@ class NASBench1shot1SearchSpace3Benchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'NASBench1shot1SearchSpace3Benchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'nasbench_1shot1')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(NASBench1shot1SearchSpace3Benchmark, self).__init__(**kwargs)

--- a/hpobench/container/benchmarks/nas/nasbench_201.py
+++ b/hpobench/container/benchmarks/nas/nasbench_201.py
@@ -10,7 +10,7 @@ class Cifar10ValidNasBench201Benchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'Cifar10ValidNasBench201Benchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'nasbench_201')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(Cifar10ValidNasBench201Benchmark, self).__init__(**kwargs)
 
 
@@ -18,7 +18,7 @@ class Cifar100NasBench201Benchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'Cifar100NasBench201Benchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'nasbench_201')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(Cifar100NasBench201Benchmark, self).__init__(**kwargs)
 
 
@@ -26,5 +26,5 @@ class ImageNetNasBench201Benchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ImageNetNasBench201Benchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'nasbench_201')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(ImageNetNasBench201Benchmark, self).__init__(**kwargs)

--- a/hpobench/container/benchmarks/nas/tabular_benchmarks.py
+++ b/hpobench/container/benchmarks/nas/tabular_benchmarks.py
@@ -11,7 +11,7 @@ class SliceLocalizationBenchmark(AbstractBenchmarkClient):
         kwargs['data_path'] = '/home/fcnet_tabular_benchmarks'
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'SliceLocalizationBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'tabular_benchmarks')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(SliceLocalizationBenchmark, self).__init__(**kwargs)
 
 
@@ -20,7 +20,7 @@ class ProteinStructureBenchmark(AbstractBenchmarkClient):
         kwargs['data_path'] = '/home/fcnet_tabular_benchmarks'
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ProteinStructureBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'tabular_benchmarks')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(ProteinStructureBenchmark, self).__init__(**kwargs)
 
 
@@ -29,7 +29,7 @@ class NavalPropulsionBenchmark(AbstractBenchmarkClient):
         kwargs['data_path'] = '/home/fcnet_tabular_benchmarks'
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'NavalPropulsionBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'tabular_benchmarks')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(NavalPropulsionBenchmark, self).__init__(**kwargs)
 
 
@@ -38,5 +38,5 @@ class ParkinsonsTelemonitoringBenchmark(AbstractBenchmarkClient):
         kwargs['data_path'] = '/home/fcnet_tabular_benchmarks'
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParkinsonsTelemonitoringBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'tabular_benchmarks')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(ParkinsonsTelemonitoringBenchmark, self).__init__(**kwargs)

--- a/hpobench/container/benchmarks/rl/cartpole.py
+++ b/hpobench/container/benchmarks/rl/cartpole.py
@@ -10,7 +10,7 @@ class CartpoleReduced(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'CartpoleReduced')
         kwargs['container_name'] = kwargs.get('container_name', 'cartpole')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(CartpoleReduced, self).__init__(**kwargs)
 
 
@@ -18,5 +18,5 @@ class CartpoleFull(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'CartpoleFull')
         kwargs['container_name'] = kwargs.get('container_name', 'cartpole')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(CartpoleFull, self).__init__(**kwargs)

--- a/hpobench/container/benchmarks/rl/learna_benchmark.py
+++ b/hpobench/container/benchmarks/rl/learna_benchmark.py
@@ -11,7 +11,7 @@ class Learna(AbstractBenchmarkClient):
         kwargs['data_path'] = '/home/learna/data'
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'Learna')
         kwargs['container_name'] = kwargs.get('container_name', 'learna_benchmark')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(Learna, self).__init__(**kwargs)
 
 
@@ -20,5 +20,5 @@ class MetaLearna(AbstractBenchmarkClient):
         kwargs['data_path'] = '/home/learna/data'
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'MetaLearna')
         kwargs['container_name'] = kwargs.get('container_name', 'learna_benchmark')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(MetaLearna, self).__init__(**kwargs)

--- a/hpobench/container/benchmarks/surrogates/paramnet_benchmark.py
+++ b/hpobench/container/benchmarks/surrogates/paramnet_benchmark.py
@@ -11,7 +11,7 @@ class ParamNetAdultOnStepsBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetAdultOnStepsBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(ParamNetAdultOnStepsBenchmark, self).__init__(**kwargs)
 
 
@@ -19,7 +19,7 @@ class ParamNetAdultOnTimeBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetAdultOnTimeBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(ParamNetAdultOnTimeBenchmark, self).__init__(**kwargs)
 
 
@@ -27,7 +27,7 @@ class ParamNetHiggsOnStepsBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetHiggsOnStepsBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(ParamNetHiggsOnStepsBenchmark, self).__init__(**kwargs)
 
 
@@ -35,7 +35,7 @@ class ParamNetHiggsOnTimeBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetHiggsOnTimeBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(ParamNetHiggsOnTimeBenchmark, self).__init__(**kwargs)
 
 
@@ -43,7 +43,7 @@ class ParamNetLetterOnStepsBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetLetterOnStepsBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(ParamNetLetterOnStepsBenchmark, self).__init__(**kwargs)
 
 
@@ -51,7 +51,7 @@ class ParamNetLetterOnTimeBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetLetterOnTimeBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(ParamNetLetterOnTimeBenchmark, self).__init__(**kwargs)
 
 
@@ -59,7 +59,7 @@ class ParamNetMnistOnStepsBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetMnistOnStepsBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(ParamNetMnistOnStepsBenchmark, self).__init__(**kwargs)
 
 
@@ -67,7 +67,7 @@ class ParamNetMnistOnTimeBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetMnistOnTimeBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(ParamNetMnistOnTimeBenchmark, self).__init__(**kwargs)
 
 
@@ -75,7 +75,7 @@ class ParamNetOptdigitsOnStepsBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetOptdigitsOnStepsBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(ParamNetOptdigitsOnStepsBenchmark, self).__init__(**kwargs)
 
 
@@ -83,7 +83,7 @@ class ParamNetOptdigitsOnTimeBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetOptdigitsOnTimeBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(ParamNetOptdigitsOnTimeBenchmark, self).__init__(**kwargs)
 
 
@@ -91,7 +91,7 @@ class ParamNetPokerOnStepsBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetPokerOnStepsBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(ParamNetPokerOnStepsBenchmark, self).__init__(**kwargs)
 
 
@@ -99,5 +99,5 @@ class ParamNetPokerOnTimeBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetPokerOnTimeBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(ParamNetPokerOnTimeBenchmark, self).__init__(**kwargs)

--- a/hpobench/container/benchmarks/surrogates/paramnet_benchmark.py
+++ b/hpobench/container/benchmarks/surrogates/paramnet_benchmark.py
@@ -11,7 +11,7 @@ class ParamNetAdultOnStepsBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetAdultOnStepsBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetAdultOnStepsBenchmark, self).__init__(**kwargs)
 
 
@@ -19,7 +19,7 @@ class ParamNetAdultOnTimeBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetAdultOnTimeBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetAdultOnTimeBenchmark, self).__init__(**kwargs)
 
 
@@ -27,7 +27,7 @@ class ParamNetHiggsOnStepsBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetHiggsOnStepsBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetHiggsOnStepsBenchmark, self).__init__(**kwargs)
 
 
@@ -35,7 +35,7 @@ class ParamNetHiggsOnTimeBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetHiggsOnTimeBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetHiggsOnTimeBenchmark, self).__init__(**kwargs)
 
 
@@ -43,7 +43,7 @@ class ParamNetLetterOnStepsBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetLetterOnStepsBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetLetterOnStepsBenchmark, self).__init__(**kwargs)
 
 
@@ -51,7 +51,7 @@ class ParamNetLetterOnTimeBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetLetterOnTimeBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetLetterOnTimeBenchmark, self).__init__(**kwargs)
 
 
@@ -59,7 +59,7 @@ class ParamNetMnistOnStepsBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetMnistOnStepsBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetMnistOnStepsBenchmark, self).__init__(**kwargs)
 
 
@@ -67,7 +67,7 @@ class ParamNetMnistOnTimeBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetMnistOnTimeBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetMnistOnTimeBenchmark, self).__init__(**kwargs)
 
 
@@ -75,7 +75,7 @@ class ParamNetOptdigitsOnStepsBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetOptdigitsOnStepsBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetOptdigitsOnStepsBenchmark, self).__init__(**kwargs)
 
 
@@ -83,7 +83,7 @@ class ParamNetOptdigitsOnTimeBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetOptdigitsOnTimeBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetOptdigitsOnTimeBenchmark, self).__init__(**kwargs)
 
 
@@ -91,7 +91,7 @@ class ParamNetPokerOnStepsBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetPokerOnStepsBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetPokerOnStepsBenchmark, self).__init__(**kwargs)
 
 
@@ -99,5 +99,5 @@ class ParamNetPokerOnTimeBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetPokerOnTimeBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetPokerOnTimeBenchmark, self).__init__(**kwargs)

--- a/hpobench/container/client_abstract_benchmark.py
+++ b/hpobench/container/client_abstract_benchmark.py
@@ -254,9 +254,20 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
         # Give each instance a little bit time to start
         time.sleep(1)
 
-        cmd = f'{env_vars} singularity run {gpu_opt}instance://{self.socket_id} {benchmark_name} {self.socket_id}'
+        # cmd = f'/bin/sh {env_vars} singularity run {gpu_opt}instance://{self.socket_id} {benchmark_name} {self.socket_id}'
+        # cmd = f'export SINGULARITYENV_HPOBENCH_DEBUG=true && singularity run {gpu_opt}instance://{self.socket_id} {benchmark_name} {self.socket_id}'
+        cmd = f'singularity run {gpu_opt}instance://{self.socket_id} {benchmark_name} {self.socket_id}'
         logger.debug(cmd)
-        subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        subprocess.Popen(cmd.split(), # stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                         shell=False,
+                         env={**os.environ, **{'SINGULARITYENV_HPOBENCH_DEBUG': 'true'}})
+        # test_command = f'singularity exec instance://{self.socket_id} env'
+        # p = subprocess.Popen(test_command.split(), stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        #                  shell=False,
+        #                  env={**os.environ, **{'SINGULARITYENV_HPOBENCH_DEBUG': 'true'}})
+        #
+        # o, e = p.communicate()
+        # assert 'HPOBENCH_DEBUG=true' in str(o)
 
         Pyro4.config.REQUIRE_EXPOSE = False
         # Generate Pyro 4 URI for connecting to client

--- a/hpobench/container/client_abstract_benchmark.py
+++ b/hpobench/container/client_abstract_benchmark.py
@@ -256,7 +256,7 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
 
         cmd = f'{env_vars} singularity run {gpu_opt}instance://{self.socket_id} {benchmark_name} {self.socket_id}'
         logger.debug(cmd)
-        subprocess.Popen(cmd.split())
+        subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
 
         Pyro4.config.REQUIRE_EXPOSE = False
         # Generate Pyro 4 URI for connecting to client

--- a/hpobench/container/client_abstract_benchmark.py
+++ b/hpobench/container/client_abstract_benchmark.py
@@ -66,12 +66,13 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
                  gpu: Optional[bool] = False, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
 
         self.socket_id = self._id_generator()
-        self._setup(benchmark_name, container_name, container_tag, container_source, env_str, bind_str, gpu, rng,
+        self._setup(benchmark_name, container_name, container_source, container_tag, env_str, bind_str, gpu, rng,
                     **kwargs)
 
-    def _setup(self, benchmark_name: str, container_name: str, container_tag: str,
-               container_source: Optional[str] = None, env_str: Optional[str] = '', bind_str: Optional[str] = '',
-               gpu: bool = False, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
+    def _setup(self, benchmark_name: str, container_name: str, container_source: Optional[str] = None,
+               container_tag: str = 'latest', env_str: Optional[str] = '', bind_str: Optional[str] = '',
+               gpu: Optional[bool] = False, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
+
         """ Initialization of the benchmark using container.
 
         This setup function downloads the container from a defined source. The source is defined either in the

--- a/hpobench/container/client_abstract_benchmark.py
+++ b/hpobench/container/client_abstract_benchmark.py
@@ -205,12 +205,12 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
 
             logger.debug('Image found on the local file system.')
 
-        env_vars = 'HPOBENCH_DEBUG={log_level_str} '
+        env_vars = f'HPOBENCH_DEBUG={log_level_str}'
         if env_str.strip() != '':
             # Following the documentation of singularity, actually all env variables should have a
             # 'SINGULARITYENV_'-prefix. However, it works also without it. We want as environmental variables input
             # a string of form VAR1=VAL1,VAR2=VAL2,...
-            env_vars += env_str.replace(' ', '').replace(',', ' ') + ' '
+            env_vars += ' ' + env_str.replace(' ', '').replace(',', ' ') + ' '
 
         bind_options = f'--bind ' \
                        f'{self.config.cache_dir}:{self.config._cache_dir_container},' \

--- a/hpobench/container/recipes/Singularity.template
+++ b/hpobench/container/recipes/Singularity.template
@@ -28,7 +28,9 @@ VERSION v0.0.1
     && echo "Please don't touch the following lines"
     && cd / \
     && mkdir /var/lib/hpobench/ \
-    && chmod -R 777 /var/lib/hpobench/
+    && chmod -R 777 /var/lib/hpobench/ \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip cache purge
 
     echo "Finally, please change the benchmark in the runscript to point to your benchmark"
 

--- a/hpobench/container/recipes/ml/Singularity.PyBNN
+++ b/hpobench/container/recipes/ml/Singularity.PyBNN
@@ -15,7 +15,9 @@ VERSION v0.0.1
     && pip install .[pybnn] \
     && cd / \
     && mkdir /var/lib/hpobench/ \
-    && chmod -R 777 /var/lib/hpobench/
+    && chmod -R 777 /var/lib/hpobench/ \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip cache purge
 
 %runscript
     python -s /home/HPOBench/hpobench/container/server_abstract_benchmark.py ml.pybnn $@

--- a/hpobench/container/recipes/ml/Singularity.SupportVectorMachine
+++ b/hpobench/container/recipes/ml/Singularity.SupportVectorMachine
@@ -15,7 +15,9 @@ VERSION v0.0.1
     && pip install .[svm] \
     && cd / \
     && mkdir /var/lib/hpobench/ \
-    && chmod -R 777 /var/lib/hpobench/
+    && chmod -R 777 /var/lib/hpobench/ \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip cache purge
 
 %runscript
     python -s /home/HPOBench/hpobench/container/server_abstract_benchmark.py ml.svm_benchmark $@

--- a/hpobench/container/recipes/ml/Singularity.XGBoostBenchmark
+++ b/hpobench/container/recipes/ml/Singularity.XGBoostBenchmark
@@ -15,7 +15,10 @@ VERSION v0.0.1
     && pip install .[xgboost] \
     && cd / \
     && mkdir /var/lib/hpobench/ \
-    && chmod -R 777 /var/lib/hpobench/
+    && chmod -R 777 /var/lib/hpobench/ \
+    && pip cache purge \
+    && rm -rf /var/lib/apt/lists/*
+
 
 %runscript
     python -s /home/HPOBench/hpobench/container/server_abstract_benchmark.py ml.xgboost_benchmark $@

--- a/hpobench/container/recipes/nas/Singularity.TabularBenchmarks
+++ b/hpobench/container/recipes/nas/Singularity.TabularBenchmarks
@@ -22,7 +22,9 @@ VERSION v0.0.1
     && pip install .[tabular_benchmarks] \
     && cd / \
     && mkdir /var/lib/hpobench/ \
-    && chmod -R 777 /var/lib/hpobench/
+    && chmod -R 777 /var/lib/hpobench/ \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip cache purge
 
 %runscript
     python -s /home/HPOBench/hpobench/container/server_abstract_benchmark.py nas.tabular_benchmarks $@

--- a/hpobench/container/recipes/nas/Singularity.nasbench_101
+++ b/hpobench/container/recipes/nas/Singularity.nasbench_101
@@ -18,7 +18,9 @@ VERSION v0.0.1
     && pip install .[nasbench_101] \
     && cd / \
     && mkdir /var/lib/hpobench/ \
-    && chmod -R 777 /var/lib/hpobench/
+    && chmod -R 777 /var/lib/hpobench/ \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip cache purge
 
 %runscript
     python -s /home/HPOBench/hpobench/container/server_abstract_benchmark.py nas.nasbench_101 $@

--- a/hpobench/container/recipes/nas/Singularity.nasbench_1shot1
+++ b/hpobench/container/recipes/nas/Singularity.nasbench_1shot1
@@ -9,8 +9,8 @@ VERSION v0.0.1
     export PYTHONPATH=/home/nasbench-1shot1:$PYTHONPATH
 
 %post
-    apt update -y
-    apt install build-essential git wget -y
+    apt update -y \
+    && apt install build-essential git wget -y
 
     cd /home \
     && pip install tensorflow==1.15.0 \
@@ -22,7 +22,9 @@ VERSION v0.0.1
     && pip install .[nasbench_1shot1] \
     && cd / \
     && mkdir /var/lib/hpobench/ \
-    && chmod -R 777 /var/lib/hpobench/
+    && chmod -R 777 /var/lib/hpobench/ \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip cache purge
 
 %runscript
     python -s /home/HPOBench/hpobench/container/server_abstract_benchmark.py nas.nasbench_1shot1 $@

--- a/hpobench/container/recipes/nas/Singularity.nasbench_201
+++ b/hpobench/container/recipes/nas/Singularity.nasbench_201
@@ -16,7 +16,9 @@ VERSION v0.0.1
     && pip install . \
     && cd / \
     && mkdir /var/lib/hpobench/ \
-    && chmod -R 777 /var/lib/hpobench/
+    && chmod -R 777 /var/lib/hpobench/ \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip cache purge
 
 %runscript
     python -s /home/HPOBench/hpobench/container/server_abstract_benchmark.py nas.nasbench_201 $@

--- a/hpobench/container/recipes/rl/Singularity.Cartpole
+++ b/hpobench/container/recipes/rl/Singularity.Cartpole
@@ -6,9 +6,9 @@ MAINTAINER muelleph@cs.uni-freiburg.de
 VERSION v0.0.1
 
 %post
-    apt update -y
-    apt install build-essential git -y
-    pip install numpy==1.18.1 cython==0.29.14
+    apt update -y \
+    && apt install build-essential git -y \
+    && pip install numpy==1.18.1 cython==0.29.14
 
     cd /home \
     && git clone https://github.com/automl/HPOBench.git \
@@ -17,7 +17,9 @@ VERSION v0.0.1
     && pip install .[cartpole] \
     && cd / \
     && mkdir /var/lib/hpobench/ \
-    && chmod -R 777 /var/bench/hpobench/
+    && chmod -R 777 /var/lib/hpobench/ \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip cache purge
 
 %runscript
     python -s /home/HPOBench/hpobench/container/server_abstract_benchmark.py rl.cartpole $@

--- a/hpobench/container/recipes/rl/Singularity.learnaBenchmark
+++ b/hpobench/container/recipes/rl/Singularity.learnaBenchmark
@@ -6,14 +6,16 @@ MAINTAINER muelleph@cs.uni-freiburg.de
 VERSION v0.0.1
 
 %post
-    apt update -y
-    apt install build-essential git wget -y
+    apt update -y \
+    && apt install build-essential git wget -y
 
     cd /home \
     && git clone --single-branch --branch development https://github.com/PhMueller/learna.git \
     && cd learna \
     && ./thirdparty/miniconda/make_miniconda.sh \
     && ./thirdparty/miniconda/miniconda/bin/conda env create -f environment.yml \
+    && ./thirdparty/miniconda/miniconda/envs/learna/bin/python -m pip install docutils==0.16 \
+    && ./thirdparty/miniconda/miniconda/envs/learna/bin/python -m pip install tensorforce==0.3.3 \
     && ./thirdparty/miniconda/miniconda/envs/learna/bin/python -m pip install . \
     && ./thirdparty/miniconda/miniconda/envs/learna/bin/python -m learna.data.download_and_build_eterna ./learna/data/secondaries_to_single_files.sh data/eterna data/eterna/interim/eterna.txt \
     && ./learna/data/download_and_build_rfam_taneda.sh \
@@ -30,7 +32,9 @@ VERSION v0.0.1
     && ../learna/thirdparty/miniconda/miniconda/envs/learna/bin/python -m pip install . \
     && cd / \
     && mkdir /var/lib/hpobench/ \
-    && chmod -R 777 /var/lib/hpobench/
+    && chmod -R 777 /var/lib/hpobench/ \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip cache purge
 
 %runscript
     /home/learna/thirdparty/miniconda/miniconda/envs/learna/bin/python -s \

--- a/hpobench/container/recipes/surrogates/Singularity.ParamnetBenchmark
+++ b/hpobench/container/recipes/surrogates/Singularity.ParamnetBenchmark
@@ -16,7 +16,9 @@ VERSION v0.0.1
     && pip install --upgrade .[paramnet] \
     && cd / \
     && mkdir /var/lib/hpobench/ \
-    && chmod -R 777 /var/lib/hpobench/
+    && chmod -R 777 /var/lib/hpobench/ \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip cache purge
 
 %runscript
     python -s /home/HPOBench/hpobench/container/server_abstract_benchmark.py surrogates.paramnet_benchmark $@

--- a/hpobench/container/server_abstract_benchmark.py
+++ b/hpobench/container/server_abstract_benchmark.py
@@ -23,14 +23,11 @@ from hpobench.util.container_utils import BenchmarkEncoder, BenchmarkDecoder
 # Read in the verbosity level from the environment variable HPOBENCH_DEBUG
 log_level_str = os.environ.get('HPOBENCH_DEBUG', 'false')
 LOG_LEVEL = logging.DEBUG if log_level_str == 'true' else logging.INFO
-print(f'Container: LOGLEVEL: {LOG_LEVEL}')
 
-# console = logging.StreamHandler()
-# console.setLevel(LOG_LEVEL)
+root = logging.getLogger()
+root.setLevel(LOG_LEVEL)
 
 logger = logging.getLogger('BenchmarkServer')
-logger.setLevel(LOG_LEVEL)
-# logger.addHandler(console)
 
 
 @Pyro4.expose
@@ -43,9 +40,9 @@ class BenchmarkServer:
 
         self.socket_id = socket_id
         socket_path = config.socket_dir / (self.socket_id + "_unix.sock")
-        logger.debug(f'Container: Socket Path: {socket_path}')
-        logger.info(f'Container: INFO')
-        print(logger.parent.level)
+        logger.debug(f'Socket Path: {socket_path}')
+        logger.info(f'Logging level: {logger.level}')
+
         if socket_path.exists():
             os.remove(socket_path)
         self.daemon = Pyro4.Daemon(unixsocket=str(socket_path))

--- a/hpobench/container/server_abstract_benchmark.py
+++ b/hpobench/container/server_abstract_benchmark.py
@@ -23,6 +23,7 @@ from hpobench.util.container_utils import BenchmarkEncoder, BenchmarkDecoder
 # Read in the verbosity level from the environment variable HPOBENCH_DEBUG
 log_level_str = os.environ.get('HPOBENCH_DEBUG', 'false')
 LOG_LEVEL = logging.DEBUG if log_level_str == 'true' else logging.INFO
+print(f'Container: LOGLEVEL: {LOG_LEVEL}')
 
 # console = logging.StreamHandler()
 # console.setLevel(LOG_LEVEL)
@@ -42,6 +43,9 @@ class BenchmarkServer:
 
         self.socket_id = socket_id
         socket_path = config.socket_dir / (self.socket_id + "_unix.sock")
+        logger.debug(f'Container: Socket Path: {socket_path}')
+        logger.info(f'Container: INFO')
+        print(logger.parent.level)
         if socket_path.exists():
             os.remove(socket_path)
         self.daemon = Pyro4.Daemon(unixsocket=str(socket_path))

--- a/tests/test_hpobenchconfig.py
+++ b/tests/test_hpobenchconfig.py
@@ -12,3 +12,16 @@ def test_version_check():
     assert not HPOBenchConfig._check_version(None, '0.0.1')
     assert not HPOBenchConfig._check_version(None, '0.0.6')
     assert not HPOBenchConfig._check_version('0.0.5', '0.0.6')
+
+
+def test_is_container():
+    import os
+    os.environ['SINGULARITY_NAME'] = 'test_name'
+    from hpobench.config import HPOBenchConfig
+
+    config = HPOBenchConfig()
+    assert config._is_container
+
+    del os.environ['SINGULARITY_NAME']
+    config = HPOBenchConfig()
+    assert not config._is_container

--- a/tests/test_hpobenchconfig.py
+++ b/tests/test_hpobenchconfig.py
@@ -19,8 +19,12 @@ def test_is_container():
     os.environ['SINGULARITY_NAME'] = 'test_name'
     from hpobench.config import HPOBenchConfig
 
-    config = HPOBenchConfig()
-    assert config._is_container
+    try:
+        config = HPOBenchConfig()
+    except PermissionError as err:
+        # We now if the link is set to /var/lib/hpobench  that it is looking for the socket dir for the container
+        # thus, it has set the _is_container - flag.
+        assert str(err) == '[Errno 13] Permission denied: \'/var/lib/hpobench\''
 
     del os.environ['SINGULARITY_NAME']
     config = HPOBenchConfig()


### PR DESCRIPTION
This PR includes: 
* On some clusters, the HPOBench was not able to mount the necessary directories into the container. As consequence, the container was not able to read the configuration file. But since the container does not depend on the configuration file, it does not read the hpobenchrc file anymore. (see #93)
* The local socket/cache/data are now linked to fix directories in the container. (var/lib/hpobench/x) via the --env parameter. 
* I have removed the global data directory from the hpobench, because it seems to be legacy and I can't see a clear use-case for it anymore.

The next steps are:
* Add a note to the readme that the user needs to have read-write rights to the 3 directories cache, socket, data dir. 
* Upload some updated containers and try it on the Nemo cluster