### PR TITLE
[skip ci] Suppress scikit-learn warnings

### DIFF
--- a/hpobench/benchmarks/surrogates/paramnet_benchmark.py
+++ b/hpobench/benchmarks/surrogates/paramnet_benchmark.py
@@ -47,6 +47,10 @@ pip install .[paramnet]
 
 Changelog:
 ==========
+0.0.3:
+* Fix returned dictionary from Objective Function for ParamNetOnTime Benchmarks.
+* Suppress Warning (Surrogate was created with scikit-learn version 0.18.1 and current is 0.23.2)
+
 0.0.2:
 * Fix OnTime Test function:
   The `objective_test_function` of the OnTime Benchmarks now checks if the budget is the right maximum budget.
@@ -55,7 +59,7 @@ Changelog:
 0.0.1:
 * First implementation
 """
-
+import warnings
 import logging
 from typing import Union, Dict
 
@@ -65,7 +69,7 @@ import numpy as np
 from hpobench.abstract_benchmark import AbstractBenchmark
 from hpobench.util.data_manager import ParamNetDataManager
 
-__version__ = '0.0.2'
+__version__ = '0.0.3'
 
 logger = logging.getLogger('Paramnet')
 
@@ -91,9 +95,10 @@ class _ParamnetBase(AbstractBenchmark):
         assert dataset in allowed_datasets, f'Requested data set is not supported. Must be one of ' \
                                             f'{", ".join(allowed_datasets)}, but was {dataset}'
         logger.info(f'Start Benchmark on dataset {dataset}')
-
-        dm = ParamNetDataManager(dataset=dataset)
-        self.surrogate_objective, self.surrogate_costs = dm.load()
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="Trying to unpickle")
+            dm = ParamNetDataManager(dataset=dataset)
+            self.surrogate_objective, self.surrogate_costs = dm.load()
 
     @staticmethod
     def convert_config_to_array(configuration: Dict) -> np.ndarray:

--- a/hpobench/container/benchmarks/surrogates/paramnet_benchmark.py
+++ b/hpobench/container/benchmarks/surrogates/paramnet_benchmark.py
@@ -11,7 +11,7 @@ class ParamNetAdultOnStepsBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetAdultOnStepsBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetAdultOnStepsBenchmark, self).__init__(**kwargs)
 
 
@@ -19,7 +19,7 @@ class ParamNetAdultOnTimeBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetAdultOnTimeBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetAdultOnTimeBenchmark, self).__init__(**kwargs)
 
 
@@ -27,7 +27,7 @@ class ParamNetHiggsOnStepsBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetHiggsOnStepsBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetHiggsOnStepsBenchmark, self).__init__(**kwargs)
 
 
@@ -35,7 +35,7 @@ class ParamNetHiggsOnTimeBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetHiggsOnTimeBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetHiggsOnTimeBenchmark, self).__init__(**kwargs)
 
 
@@ -43,7 +43,7 @@ class ParamNetLetterOnStepsBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetLetterOnStepsBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetLetterOnStepsBenchmark, self).__init__(**kwargs)
 
 
@@ -51,7 +51,7 @@ class ParamNetLetterOnTimeBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetLetterOnTimeBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetLetterOnTimeBenchmark, self).__init__(**kwargs)
 
 
@@ -59,7 +59,7 @@ class ParamNetMnistOnStepsBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetMnistOnStepsBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetMnistOnStepsBenchmark, self).__init__(**kwargs)
 
 
@@ -67,7 +67,7 @@ class ParamNetMnistOnTimeBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetMnistOnTimeBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetMnistOnTimeBenchmark, self).__init__(**kwargs)
 
 
@@ -75,7 +75,7 @@ class ParamNetOptdigitsOnStepsBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetOptdigitsOnStepsBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetOptdigitsOnStepsBenchmark, self).__init__(**kwargs)
 
 
@@ -83,7 +83,7 @@ class ParamNetOptdigitsOnTimeBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetOptdigitsOnTimeBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetOptdigitsOnTimeBenchmark, self).__init__(**kwargs)
 
 
@@ -91,7 +91,7 @@ class ParamNetPokerOnStepsBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetPokerOnStepsBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetPokerOnStepsBenchmark, self).__init__(**kwargs)
 
 
@@ -99,5 +99,5 @@ class ParamNetPokerOnTimeBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParamNetPokerOnTimeBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'paramnet')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.2')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
         super(ParamNetPokerOnTimeBenchmark, self).__init__(**kwargs)


### PR DESCRIPTION
* Every time the benchmark was created, Scikit-learn showed a warning that the surrogate was created with an older scikit-learn version.
* Unfortunately, we can't set scikit-learn in the requirements to this old version, because it throws a dependency error. I set it therefore to a newer version and have suppressed the warnings. This works, but there is another deprecation warning we can't suppress since scikit-learn does not allow this. (https://github.com/scikit-learn/scikit-learn/pull/15080)
* Increase benchmark version