### PR TITLE
Surrogates SVM Benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ pip install .
 | NASBench1shot1SearchSpace*Benchmark | nasbench_1shot1  | Loading may take several minutes. There are 3 benchmarks in total (1,2,3) |
 | ParamNet*OnStepsBenchmark       | paramnet         | There are 6 benchmarks in total (Adult, Higgs, Letter, Mnist, Optdigits, Poker) |
 | ParamNet*OnTimeBenchmark        | paramnet         | There are 6 benchmarks in total (Adult, Higgs, Letter, Mnist, Optdigits, Poker) |
+| SurrogateSVMBenchmark              | surrogate_svm      | A svm surrogate benchmark on MNIST. |
 | Learna⁺                            | learna_benchmark   | Not deterministic.                    |
 | MetaLearna⁺                        | learna_benchmark   | Not deterministic.                    |
 | XGBoostBenchmark⁺                  | xgboost_benchmark  | Works with OpenML task ids. |

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # 0.0.8
+  * Add the surrogate SVM on MNIST benchmark from the BOHB paper. 
 
 # 0.0.7
   * Fix an error in the NASBench1shot1 Benchmark (SearchSpace3).

--- a/hpobench/benchmarks/surrogates/paramnet_benchmark.py
+++ b/hpobench/benchmarks/surrogates/paramnet_benchmark.py
@@ -30,11 +30,8 @@ a hard requirement of scikit-learn==0.23.x.
 
 1. Clone from github:
 =====================
-Clone the learna tool and install it to your Conda environment.
 ```
-git clone --single-branch --branch development https://github.com/PhMueller/learna.git
-cd learna
-pip install .
+git clone HPOBench
 ```
 
 2. Clone and install

--- a/hpobench/benchmarks/surrogates/svm_benchmark.py
+++ b/hpobench/benchmarks/surrogates/svm_benchmark.py
@@ -1,0 +1,186 @@
+"""
+How to use this benchmark:
+--------------------------
+
+We recommend using the containerized version of this benchmark.
+If you want to use this benchmark locally (without running it via the corresponding container),
+you need to perform the following steps.
+
+Prerequisites:
+==============
+Conda environment in which the HPOBench is installed (pip install .). Activate your environment.
+```
+conda activate <Name_of_Conda_HPOBench_environment>
+```
+
+1. Download data:
+=================
+The data will be downloaded automatically.
+
+If you want to download the data on your own, you can download the data with the following command and then link the
+hpobench-config's data-path to it.
+
+```
+wget https://www.automl.org/wp-content/uploads/2019/05/surrogates.tar.gz
+```
+
+The data consist of surrogates for different data sets. Each surrogate is a pickled scikit-learn forest. Thus, we have
+a hard requirement of scikit-learn==0.23.x.
+
+
+1. Clone from github:
+=====================
+```
+git clone HPOBench
+```
+
+2. Clone and install
+====================
+```
+cd /path/to/HPOBench
+pip install .[paramnet]
+
+```
+
+Changelog:
+==========
+0.0.1:
+* First implementation
+"""
+
+import logging
+from typing import Union, Dict
+
+import ConfigSpace as CS
+import numpy as np
+
+from hpobench.abstract_benchmark import AbstractBenchmark
+from hpobench.util.data_manager import SurrogateSVMDataManager
+
+__version__ = '0.0.1'
+
+logger = logging.getLogger('SurrogateSVM')
+
+
+class SurrogateSVMBenchmark(AbstractBenchmark):
+
+    def __init__(self, rng: Union[np.random.RandomState, int, None] = None):
+        """
+        Parameters
+        ----------
+        rng : np.random.RandomState, int, None
+        """
+
+        # TODO: What is the minimal data set fraction? What was the original dataset size the surrogate was trained on?
+        self.s_min = 100 / 50000.
+        # In ml/svm: maybe similar?
+        # self.lower_bound_train_size = (10 * n_classes) / self.x_train.shape[0]
+
+        dm = SurrogateSVMDataManager()
+        self.surrogate_objective, self.surrogate_costs = dm.load()
+
+        super(SurrogateSVMBenchmark, self).__init__(rng=rng)
+
+    @staticmethod
+    def get_configuration_space(seed: Union[int, None] = None) -> CS.ConfigurationSpace:
+        """
+        Parameters
+        ----------
+        seed : int, None
+            Fixing the seed for the ConfigSpace.ConfigurationSpace
+
+        Returns
+        -------
+        ConfigSpace.ConfigurationSpace
+        """
+        seed = seed if seed is not None else np.random.randint(1, 100000)
+        cs = CS.ConfigurationSpace(seed=seed)
+        cs.add_hyperparameters([
+            CS.UniformFloatHyperparameter('C', lower=-10, upper=10, default_value=0, log=False),
+            CS.UniformFloatHyperparameter('gamma', lower=-10, upper=10, default_value=0, log=False)
+        ])
+        return cs
+
+    @staticmethod
+    def get_fidelity_space(seed: Union[int, None] = None) -> CS.ConfigurationSpace:
+        """
+        Creates a ConfigSpace.ConfigurationSpace containing all fidelity parameters for
+        the SupportVector Benchmark
+
+        Fidelities
+        ----------
+        dataset_fraction: float - [0.1, 1]
+            fraction of training data set to use
+
+        Parameters
+        ----------
+        seed : int, None
+            Fixing the seed for the ConfigSpace.ConfigurationSpace
+
+        Returns
+        -------
+        ConfigSpace.ConfigurationSpace
+        """
+        seed = seed if seed is not None else np.random.randint(1, 100000)
+        fidel_space = CS.ConfigurationSpace(seed=seed)
+
+        fidel_space.add_hyperparameters([
+            CS.UniformFloatHyperparameter("dataset_fraction", lower=0.0, upper=1.0, default_value=1.0, log=False)
+        ])
+        return fidel_space
+
+    @staticmethod
+    def get_meta_information():
+        """ Returns the meta information for the benchmark """
+        return {'name': 'ParamNet Benchmark',
+                'references': ['@InProceedings{falkner-icml-18,'
+                               'title     = {{BOHB}: Robust and Efficient Hyperparameter Optimization at Scale},'
+                               'url       = http://proceedings.mlr.press/v80/falkner18a.html'
+                               'author    = {Falkner, Stefan and Klein, Aaron and Hutter, Frank}, '
+                               'booktitle = {Proceedings of the 35th International Conference on Machine Learning},'
+                               'pages     = {1436 - 1445},'
+                               'year      = {2018}}'],
+                'code': 'https://github.com/automl/HPOlib1.5/blob/development/'
+                        'hpolib/benchmarks/surrogates/paramnet.py'
+                }
+
+    @staticmethod
+    def convert_config_to_array(configuration: Dict, fidelity: Dict) -> np.ndarray:
+        """
+        This function transforms a configuration to a numpy array.
+
+        Parameters
+        ----------
+        configuration : Dict
+        fidelity : Dict
+
+        Returns
+        -------
+        np.ndarray - The configuration transformed back to its original space
+        """
+        cfg_array = np.zeros(2)
+        cfg_array[0] = configuration['C']
+        cfg_array[1] = configuration['gamma']
+        cfg_array[2] = fidelity['dataset_fraction']
+        return cfg_array.reshape((1, -1))
+
+    @AbstractBenchmark.check_parameters
+    def objective_function(self, configuration: Union[CS.Configuration, Dict],
+                           fidelity: Union[CS.Configuration, Dict, None] = None,
+                           rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
+
+        cfg_array = self.convert_config_to_array(configuration, fidelity)
+        obj_value = self.surrogate_objective.predict(cfg_array)[0]
+        cost = self.surrogate_costs.predict(cfg_array)[0]
+
+        return {'function_value': obj_value,
+                "cost": cost,
+                'info': {'fidelity': fidelity}}
+
+    @AbstractBenchmark.check_parameters
+    def objective_function_test(self, configuration: Union[CS.Configuration, Dict],
+                                fidelity: Union[CS.Configuration, Dict, None] = None,
+                                rng: Union[np.random.RandomState, int, None] = None, **kwargs) -> Dict:
+        assert fidelity['dataset_fraction'] == 1, f'Only querying a result with the maximum fidelity is allowed, ' \
+                                                  f'but was {fidelity["dataset_fraction"]}.'
+        return self.objective_function(configuration, fidelity=fidelity, rng=rng)

--- a/hpobench/container/benchmarks/surrogates/svm_benchmark.py
+++ b/hpobench/container/benchmarks/surrogates/svm_benchmark.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+""" Benchmark for the svm surrogates Benchmark from hpobench/benchmarks/surrogates/svm_benchmark.py
+"""
+
+from hpobench.container.client_abstract_benchmark import AbstractBenchmarkClient
+
+
+class SurrogateSVMBenchmark(AbstractBenchmarkClient):
+    def __init__(self, **kwargs):
+        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'SurrogateSVMBenchmark')
+        kwargs['container_name'] = kwargs.get('container_name', 'surrogatessvm')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.1')
+        super(SurrogateSVMBenchmark, self).__init__(**kwargs)

--- a/hpobench/container/benchmarks/surrogates/svm_benchmark.py
+++ b/hpobench/container/benchmarks/surrogates/svm_benchmark.py
@@ -10,6 +10,6 @@ from hpobench.container.client_abstract_benchmark import AbstractBenchmarkClient
 class SurrogateSVMBenchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'SurrogateSVMBenchmark')
-        kwargs['container_name'] = kwargs.get('container_name', 'surrogatessvm')
+        kwargs['container_name'] = kwargs.get('container_name', 'surrogate_svm')
         kwargs['latest'] = kwargs.get('container_tag', '0.0.1')
         super(SurrogateSVMBenchmark, self).__init__(**kwargs)

--- a/hpobench/container/recipes/surrogates/Singularity.SupportVectorMachine
+++ b/hpobench/container/recipes/surrogates/Singularity.SupportVectorMachine
@@ -1,0 +1,26 @@
+Bootstrap: docker
+From: python:3.7-slim
+
+%labels
+MAINTAINER muelleph@cs.uni-freiburg.de
+VERSION v0.0.1
+
+%post
+
+%post
+    apt update -y \
+    && apt install build-essential git wget -y
+
+    cd /home \
+    && git clone https://github.com/automl/HPOBench.git \
+    && cd HPOBench \
+    && git checkout master \
+    && pip install --upgrade .[paramnet] \
+    && cd / \
+    && mkdir /var/lib/hpobench/ \
+    && chmod -R 777 /var/lib/hpobench/ \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip cache purge
+
+%runscript
+    python -s /home/HPOBench/hpobench/container/server_abstract_benchmark.py surrogates.svm_benchmark $@

--- a/hpobench/util/data_manager.py
+++ b/hpobench/util/data_manager.py
@@ -644,8 +644,8 @@ class ParamNetDataManager(SurrogateDataManger):
 class SurrogateSVMDataManager(SurrogateDataManger):
     def __init__(self):
         super(SurrogateSVMDataManager, self).__init__(dataset='svm')
-        self.obj_fn_file = self.save_dir / f'rf_surrogate_svm.pkl'
-        self.cost_file = self.save_dir / f'rf_cost_surrogate_svm.pkl'
+        self.obj_fn_file = self.save_dir / 'rf_surrogate_svm.pkl'
+        self.cost_file = self.save_dir / 'rf_cost_surrogate_svm.pkl'
 
 
 class BostonHousingData(HoldoutDataManager):

--- a/hpobench/util/data_manager.py
+++ b/hpobench/util/data_manager.py
@@ -556,52 +556,24 @@ class NASBench_101DataManager(DataManager):
         return data
 
 
-class ParamNetDataManager(DataManager):
+class SurrogateDataManger(DataManager):
     def __init__(self, dataset: str):
 
-        allowed_datasets = ["adult", "higgs", "letter", "mnist", "optdigits", "poker"]
+        allowed_datasets = ["adult", "higgs", "letter", "mnist", "optdigits", "poker", "svm"]
         assert dataset in allowed_datasets, f'Requested data set is not supported. Must be one of ' \
                                             f'{", ".join(allowed_datasets)}, but was {dataset}'
 
-        super(ParamNetDataManager, self).__init__()
+        super(SurrogateDataManger, self).__init__()
 
         self.url_source = 'https://www.automl.org/wp-content/uploads/2019/05/surrogates.tar.gz'
         self.dataset = dataset
-        self.save_dir = hpobench.config_file.data_dir / "Paramnet"
+        self.save_dir = hpobench.config_file.data_dir / "Surrogates"
         self.compressed_data = self.save_dir / 'surrogates.tar.gz'
-
-    def load(self):
-        self.logger.info(f"Start to load the data from {self.save_dir} for dataset {self.dataset}")
-
-        obj_fn_file = self.save_dir / f'rf_surrogate_paramnet_{self.dataset}.pkl'
-        cost_file = self.save_dir / f'rf_cost_surrogate_paramnet_{self.dataset}.pkl'
-
-        # Check if the surrogate files are already available
-        if not (obj_fn_file.exists() or cost_file.exists()):
-            self.logger.info(f"One of the files {obj_fn_file} and {cost_file} not found.")
-
-            # If not, then check if we have to download the compressed data or if this file isn't already there,
-            # download it again.
-            self._check_availability_and_download()
-
-            # Extract the compressed data
-            self.logger.debug('Extract the compressed data')
-            with tarfile.open(self.compressed_data, 'r') as fh:
-                fh.extractall(self.save_dir)
-
-        self.logger.debug('Load the obj function values from file.')
-        with open(obj_fn_file, 'rb') as fh:
-            surrogate_objective = pickle.load(fh)
-
-        self.logger.debug('Load the cost values from file.')
-        with open(cost_file, 'rb') as fh:
-            surrogate_costs = pickle.load(fh)
-
-        self.logger.info(f'Finished loading the data for paramenet - dataset: {self.dataset}')
-        return surrogate_objective, surrogate_costs
+        self.obj_fn_file = None
+        self.cost_file = None
 
     @lockutils.synchronized('not_thread_process_safe', external=True,
-                            lock_path=f'{hpobench.config_file.cache_dir}/lock_paramnet_data', delay=0.5)
+                            lock_path=f'{hpobench.config_file.cache_dir}/lock_surrogates_data', delay=0.5)
     def _check_availability_and_download(self):
 
         # Check if the compressed data file is already available. This check is moved in this function to ensure
@@ -624,6 +596,56 @@ class ParamNetDataManager(DataManager):
                     _ = f.write(chunk)
                     f.flush()
         self.logger.info("Finished downloading")
+
+    @lockutils.synchronized('not_thread_process_safe', external=True,
+                            lock_path=f'{hpobench.config_file.cache_dir}/lock_surrogates_unzip_data', delay=0.5)
+    def _unzip_data(self):
+        self.logger.debug('Extract the compressed data')
+        with tarfile.open(self.compressed_data, 'r') as fh:
+            fh.extractall(self.save_dir)
+        self.logger.debug(f'Successfully extracted the data to {self.save_dir}')
+
+    def load(self):
+        self.logger.info(f"Start to load the data from {self.save_dir} for dataset {self.dataset}")
+
+        assert self.obj_fn_file is not None
+        assert self.cost_file is not None
+
+        # Check if the surrogate files are already available
+        if not (self.obj_fn_file.exists() or self.cost_file.exists()):
+            self.logger.info(f"One of the files {self.obj_fn_file} and {self.cost_file} not found.")
+
+            # If not, then check if we have to download the compressed data or if this file isn't already there,
+            # download it again.
+            self._check_availability_and_download()
+
+            # Extract the compressed data
+            self._unzip_data()
+
+        self.logger.debug('Load the obj function values from file.')
+        with open(self.obj_fn_file, 'rb') as fh:
+            surrogate_objective = pickle.load(fh)
+
+        self.logger.debug('Load the cost values from file.')
+        with open(self.cost_file, 'rb') as fh:
+            surrogate_costs = pickle.load(fh)
+
+        self.logger.info(f'Finished loading the data for paramenet - dataset: {self.dataset}')
+        return surrogate_objective, surrogate_costs
+
+
+class ParamNetDataManager(SurrogateDataManger):
+    def __init__(self, dataset: str):
+        super(ParamNetDataManager, self).__init__(dataset)
+        self.obj_fn_file = self.save_dir / f'rf_surrogate_paramnet_{dataset}.pkl'
+        self.cost_file = self.save_dir / f'rf_cost_surrogate_paramnet_{dataset}.pkl'
+
+
+class SurrogateSVMDataManager(SurrogateDataManger):
+    def __init__(self):
+        super(SurrogateSVMDataManager, self).__init__(dataset='svm')
+        self.obj_fn_file = self.save_dir / f'rf_surrogate_svm.pkl'
+        self.cost_file = self.save_dir / f'rf_cost_surrogate_svm.pkl'
 
 
 class BostonHousingData(HoldoutDataManager):

--- a/tests/test_svm.py
+++ b/tests/test_svm.py
@@ -26,7 +26,7 @@ def test_svm_init():
 
     result = benchmark.objective_function(configuration=config, fidelity=fidelity)
     assert result['function_value'] == pytest.approx(0.4837, abs=0.1)
-    assert result['cost'] == pytest.approx(0.323, abs=0.1)
+    assert result['cost'] is not None
 
     with pytest.raises(AssertionError):
         result = benchmark.objective_function_test(configuration=config, fidelity=fidelity)


### PR DESCRIPTION
Started to implement the surrogate Svm Benchmark used in the BOHB paper. 

Code of experiment: 
https://github.com/automl/HpBandSter/blob/176d5f774598fe289abfac0f065080c9a78ee724/icml_2018_experiments/experiments/workers/svm_surrogate.py#L10

Implementation found in: 
https://github.com/automl/HPOlib1.5/blob/container/hpolib/benchmarks/surrogates/svm.py

* Added a new data loader since it is a similar one to the paramnet data loader. 
* Removed some clearly wrong part of the paramnet docstring. 
* Initial commit of the svm benchmark. 
* Container Uploaded

Still to do: 
* ~Writing the container part~
* ~Testing the benchmark regarding the fidelity data set fraction (what is the lower bound of this fidelity?)~
* ~Upload container.~