### PR TITLE
Add startup add connect client

### DIFF
--- a/examples/container/create_connection_to_benchmark.py
+++ b/examples/container/create_connection_to_benchmark.py
@@ -1,0 +1,59 @@
+"""
+ADVANCED: Create multiple connections to a Benchmark
+====================================================
+
+Sometimes it is useful to have only a single container instance running for multiple experiments.
+For example if starting a container is very expensive.
+
+Since version 0.0.8, we can now start a benchmark container in a background process and connect to the benchmark from
+various other processes.
+This example shows how to create a benchmark and create a separate proxy connection to it.
+
+The benchmark is based on Pyro4 and should handle a certain amount of simultaneous calls.
+
+Also make sure not have to many open Pyro4.Proxy connections.
+(See https://pyro4.readthedocs.io/en/stable/tipstricks.html#after-x-simultaneous-proxy-connections-pyro-seems-to-freeze-fix-release-your-proxies-when-you-can)
+
+Please install the necessary dependencies via ``pip install .`` and singularity (v3.5).
+https://sylabs.io/guides/3.5/user-guide/quick_start.html#quick-installation-steps
+"""
+
+import argparse
+
+from hpobench.container.benchmarks.nas.tabular_benchmarks import SliceLocalizationBenchmark as TabBenchmarkContainer
+
+
+def run_experiment(on_travis=False):
+
+    # First, we start the benchmark. This generates the unix-socket (address) where the benchmark is reachable.
+    benchmark = TabBenchmarkContainer(container_name='tabular_benchmarks',
+                                      container_source='library://phmueller/automl',
+                                      rng=1)
+
+    print(benchmark.socket_id)
+
+    # Now, we could use this `socket_id` to connect to the benchmark from another process. For simplicity, we just
+    # create a new proxy connection to it.
+    # Note that you don't have to specify the container name or other things, since we only connect to it.
+
+    proxy_to_benchmark = TabBenchmarkContainer(socket_id=benchmark.socket_id)
+
+    cs = proxy_to_benchmark.get_configuration_space(seed=1)
+    config = cs.sample_configuration()
+    print(config)
+
+    # You can pass the configuration either as a dictionary or a ConfigSpace.configuration
+    result_dict_1 = proxy_to_benchmark.objective_function(configuration=config.get_dictionary())
+    result_dict_2 = proxy_to_benchmark.objective_function(configuration=config)
+    print(result_dict_1, result_dict_2)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(prog='TabularNad')
+
+    parser.add_argument('--on_travis', action='store_true',
+                        help='Flag to speed up the run on the continuous integration tool \"travis\". This flag can be'
+                             'ignored by the user')
+
+    args = parser.parse_args()
+    run_experiment(on_travis=args.on_travis)

--- a/hpobench/HowToAddANewBenchmark.md
+++ b/hpobench/HowToAddANewBenchmark.md
@@ -1,21 +1,33 @@
 # How to add a new benchmark step-by-step
 
+## Placeholders for your benchmark
+
+- `<type>`: Category of the benchmark, e.g. od (outlier detection)
+- `<Type>`: Category of the benchmark in uppercase, e.g. OD (outlier detection)
+- `<dataset_name>`: Name of the dataset (optional, ), e.g. cifar10
+- `<DatasetName>`: Name of the dataset (optional), e.g. Cifar10
+- `<new_benchmark>*`: Filename of the benchmark, e.g. `<type>`_ocsvm_`<dataset_name>`_benchmark or `<type>`_ocsvm_benchmark
+- `<NewBenchmark>*`: Classname of the benchmark, e.g. `<Type>`OCSVM`<DatasetName>`Benchmark or `<Type>`OCSVMBenchmark
+- `<branch_name>`: Branch name for your benchmarks, e.g. outlier_detection
+
+`*`: has to be unique across all available benchmarks.
+
+
 ## Create a local benchmark
 
-Clone HPOBench, switch to the development branch and create your own branch, then install hpobench. 
+Clone HPOBench, switch to the development branch and create your own branch. Then install hpobench
 with `pip install .`
 ```bash
 git clone https://github.com/automl/HPOBench.git
 cd HPOBench
 git checkout development
-git branch newBenchmark
-git checkout newBenchmark
+git branch <branch_name>
+git checkout <branch_name>
 pip install .
 ```
 
 Then: 
-
-  1. Implement your new benchmark `hpobench/benchmarks/<type>/<name>` inheriting from the base class 
+  1. Implement your new benchmark class `<NewBenchmark>` in `hpobench/benchmarks/<type>/<new_benchmark>.py` inheriting from the base class 
   `AbstractBenchmark` in `hpobench.abstract_benchmark`. Your benchmark should implement `__init__()`, 
   `get_configuration_space()`, `get_fidelity_space()`, `objective_function()` and `objective_function_test()`.
     A good example for this can be found in `hpobench/benchmarks/ml/xgboost_benchmark.py`
@@ -23,13 +35,13 @@ Then:
    `hpobench/util/openml_data_manager.py` with a `load()` method that downloads data once and reuses it for further calls.
   4. Collect all **additional Python** and **non-Python** dependencies while doing this. 
   Consider fixing the version of each dependency to maintain reproducibility.
-  5. Add dependencies to PIPy in a new file to `/extra_requirements`
+  5. Add dependencies to PyPI in a new file to `/extra_requirements`. The name of the file is secondary. However, add the dependencies as a list under the key `<new_benchmark>`.
   6. Add the remaining dependencies or steps necessary to run your benchmark in the docstring of your benchmark class
     (see, e.g. `hpobench/benchmarks/nas/nasbench_101.py`).
   7. Verify that everything works with, e.g.
 
 ```python
-from hpobench.benchmarks.<type>.<newbenchmark> import <NewBenchmark>
+from hpobench.benchmarks.<type>.<new_benchmark> import <NewBenchmark>
 b = <NewBenchmark>(<some_args>, rng=1)
 config = b.get_configuration_space(seed=1).sample_configuration()
 result_dict = b.objective_function(configuration=config, rng=1)
@@ -40,32 +52,35 @@ print(result_dict)
 
 Now, you can create a PR marked as [WIP] and proceed with building a containerized version. 
 
+
 ## Create a containerized benchmark
 
-  1. Create a container benchmark class in `hpobench/container/benchmarks/<type>/<name>` inheriting from the 
-  base class `AbstractBenchmarkClient` in `hpobench.container.client_abstract_benchmark`. 
-  Note: this are just a few lines of code, see, e.g. `hpobench/container/benchmarks/ml/xgboost_benchmark.py`)
-  2. Copy `hpobench/container/recipes/Singularity.template` to  `hpobench/container/recipes/<type>/name`
-  3. Modify the recipe and add your **additional Python** and **non-Python** dependencies collected above. 
-  3. Test your container locally (see below)
+  1. Create a container benchmark class `<NewBenchmark>` in `hpobench/container/benchmarks/<type>/<new_benchmark>.py` inheriting from the base class `AbstractBenchmarkClient` in `hpobench.container.client_abstract_benchmark`. The arguments `benchmark_name` and `container_name` should be assigned to `<NewBenchmark>`.
+  <span style="color:red">Todo: What are benchmark_name + container_name for?</span>
+  *Note: this are just a few lines of code, see, e.g. `hpobench/container/benchmarks/ml/xgboost_benchmark.py`).*.
+  2. Copy `hpobench/container/recipes/Singularity.template` to  `hpobench/container/recipes/<type>/Singularity.<NewBenchmark>`.
+  3. Modify the recipe and add your **additional Python** and **non-Python** dependencies collected above. Make sure you install the right dependencies with ```pip install .[<new_benchmark>]```.
+  3. Test your container locally (see below).
 
 Now, you can update your PR and let us know, so we can upload the container. Thanks.
   
 ## How to test your container locally
 
-  1. `cd hpobench/container/benchmarks/recipes/<type>` and change to following lines in the recipe:
+  1. `cd hpobench/container/benchmarks/recipes/<type>/Singularity.<NewBenchmark>` and change to following lines in the recipe:
   ```bash
     && git clone https://github.com/automl/HPOBench.git \
     && cd HPOBench \
     && git checkout development \
   ```
-   to point to the branch/repo where your fork is on, e.g. `newBenchmark`.
+  to point to the branch/repo where your fork is on, e.g. `<branch_name>`.
+  <span style="color:red">Todo: In Singularity.template is mentioned that you should not point to your branch.</span>
    
-  2. Run `sudo singularity build <newBenchmark> Singularity.<newBenchmark>`
+  2. Run `sudo singularity build <NewBenchmark> Singularity.<NewBenchmark>`
   3. Verify that everything works with:
 
 ```python
-from hpobench.container.benchmarks.<type>.<newbenchmark> import <NewBenchmark>
-b = <NewBenchmark>(container_source="./", container_name="newBenchmark")
+from hpobench.container.benchmarks.<type>.<new_benchmark> import <NewBenchmark>
+b = <NewBenchmark>(container_source="./", container_name="<NewBenchmark>")
 res = b.objective_function(configuration=b.get_configuration_space(seed=1).sample_configuration())
 ```
+

--- a/hpobench/HowToAddANewBenchmark.md
+++ b/hpobench/HowToAddANewBenchmark.md
@@ -6,8 +6,8 @@
 - `<Type>`: Category of the benchmark in uppercase, e.g. OD (outlier detection)
 - `<dataset_name>`: Name of the dataset (optional, ), e.g. cifar10
 - `<DatasetName>`: Name of the dataset (optional), e.g. Cifar10
-- `<new_benchmark>*`: Filename of the benchmark, e.g. `<type>`_ocsvm_`<dataset_name>`_benchmark or `<type>`_ocsvm_benchmark
-- `<NewBenchmark>*`: Classname of the benchmark, e.g. `<Type>`OCSVM`<DatasetName>`Benchmark or `<Type>`OCSVMBenchmark
+- `<new_benchmark>*`: Filename of the benchmark, e.g. `<type>`\_ocsvm\_`<dataset_name>` or `<type>`_ocsvm
+- `<NewBenchmark>*`: Classname of the benchmark, e.g. `<Type>`OCSVM`<DatasetName>` or `<Type>`OCSVM
 - `<branch_name>`: Branch name for your benchmarks, e.g. outlier_detection
 
 `*`: has to be unique across all available benchmarks.

--- a/hpobench/container/client_abstract_benchmark.py
+++ b/hpobench/container/client_abstract_benchmark.py
@@ -64,63 +64,67 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
     """
     def __init__(self, benchmark_name: str, container_name: str, container_source: Optional[str] = None,
                  container_tag: str = 'latest', env_str: Optional[str] = '', bind_str: Optional[str] = '',
-                 gpu: Optional[bool] = False, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
+                 gpu: Optional[bool] = False, rng: Union[np.random.RandomState, int, None] = None,
+                 socket_id=None, **kwargs):
 
-        self.socket_id = self._id_generator()
-        self._setup(benchmark_name, container_name, container_source, container_tag, env_str, bind_str, gpu, rng,
-                    **kwargs)
+        self.config = hpobench.config.config_file
 
-    def _setup(self, benchmark_name: str, container_name: str, container_source: Optional[str] = None,
+        # connect to already running server if a socket_id is given. In this case, skip the init of
+        # the benchmark
+        already_running = socket_id is not None
+
+        if not already_running:
+            self.socket_id = self._id_generator()
+            self.load_benchmark(benchmark_name, container_name, container_source, container_tag, env_str, bind_str, gpu, rng,
+                                **kwargs)
+            self.start_server(benchmark_name, container_name, container_source, container_tag, env_str, bind_str, gpu, rng,
+                              **kwargs)
+            self.connect_to_server()
+            self.init_benchmark(rng, **kwargs)
+        else:
+            self.socket_id = socket_id
+            self.connect_to_server()
+
+    def _parse_kwargs(self, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
+        """ Helper function to parse the named keyword arguments to json str. """
+        if rng is not None:
+            kwargs['rng'] = rng
+        if 'latest' in kwargs:
+            del kwargs['latest']
+        kwargs_str = json.dumps(kwargs, indent=None, cls=BenchmarkEncoder)
+        return kwargs_str
+
+    def _parse_configuration(self, configuration: Union[CS.Configuration, Dict]) -> str:
+        if isinstance(configuration, CS.Configuration):
+            configuration = configuration.get_dictionary()
+        elif isinstance(configuration, dict):
+            configuration = configuration
+        else:
+            raise ValueError(f'Type of config not understood: {type(configuration)}')
+        c_str = json.dumps(configuration, indent=None, cls=BenchmarkEncoder)
+        return c_str
+
+    def _parse_fidelities(self, fidelity: Union[CS.Configuration, Dict, None] = None):
+        if fidelity is None:
+            fidelity = {}
+        elif isinstance(fidelity, CS.Configuration):
+            fidelity = fidelity.get_dictionary()
+        elif isinstance(fidelity, dict):
+            fidelity = fidelity
+        else:
+            raise ValueError(f'Type of fidelity not understood: {type(fidelity)}')
+        f_str = json.dumps(fidelity, indent=None, cls=BenchmarkEncoder)
+        return f_str
+
+    def load_benchmark(self, benchmark_name: str, container_name: str, container_source: Optional[str] = None,
                container_tag: str = 'latest', env_str: Optional[str] = '', bind_str: Optional[str] = '',
                gpu: Optional[bool] = False, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
 
-        """ Initialization of the benchmark using container.
-
-        This setup function downloads the container from a defined source. The source is defined either in the
-        .hpobenchrc or in the its benchmark definition (hpobench/container/benchmarks/<type>/<name>). If an container
-        is already locally available, the local container is used. Then, the container is started and a connection
-        between the container and the client is established.
-
-        Parameters
-        ----------
-        benchmark_name: str
-            Class name of the benchmark to use. For example XGBoostBenchmark. This value is defined in the benchmark
-            definition (hpobench/container/benchmarks/<type>/<name>)
-        container_source : Optional[str]
-            Path to the container. Either local path or url to a hosting
-            platform, e.g. singularity hub.
-        container_tag : str
-            Singularity containers are specified by an address as well as a container tag. We use the tag as a version
-            number. By default the tag is set to `latest`, which then pulls the latest container from the container
-            source. The tag-versioning allows the users to rerun an experiment, which was performed with an older
-            container version. Take a look in the container_source to find the right tag to use.
-        container_name : str
-            name of the container. E.g. xgboost_benchmark. Specifying different container could be
-            useful to have multiple container for the same benchmark, if a tool like auto-sklearn is updated to a newer
-            version, and you want to compare its performance across its versions.
-            Also, a container can contain multiple benchmarks. Therefore, we have to define for each benchmark the
-            corresponding container name.
-        bind_str : Optional[str]
-            Defaults to ''. You can bind further directories into the container.
-            This string have the form src[:dest[:opts]].
-            For more information, see https://sylabs.io/guides/3.5/user-guide/bind_paths_and_mounts.html
-        env_str : Optional[str]
-            Defaults to ''. Sometimes you want to pass a parameter to your container. You can do this by setting some
-            environmental variables. The list should follow the form VAR1=VALUE1,VAR2=VALUE2,..
-            For more information, see
-            https://sylabs.io/guides/3.5/user-guide/environment_and_metadata.html#environment-overview
-        gpu : bool
-            If True, the container has access to the local cuda-drivers.
-            (Not tested)
-        """
-        # Create unique ID
-        self.config = hpobench.config.config_file
-
         # We can point to a different container source. See below.
-        container_source = container_source or self.config.container_source
-        container_dir = Path(self.config.container_dir)
+        self.container_source = container_source or self.config.container_source
+        self.container_dir = Path(self.config.container_dir)
 
-        if (container_source.startswith('oras://gitlab.tf.uni-freiburg.de:5050/muelleph/hpobench-registry')
+        if (self.container_source.startswith('oras://gitlab.tf.uni-freiburg.de:5050/muelleph/hpobench-registry')
                 and container_tag == 'latest'):
             assert 'latest' in kwargs, 'If the container is hosted on the gitlab registry, make sure that in the ' \
                                        'container init, the field \'latest\' is set.'
@@ -128,15 +132,15 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
             container_tag = kwargs['latest']
             logger.debug(f'Replace the tag \'latest\' with \'{container_tag}\'.')
 
-        container_name_with_tag = f'{container_name}_{container_tag}'
+        self.container_name_with_tag = f'{container_name}_{container_tag}'
         logger.info(f'~~~ HPOBENCH VERSION: {__version__} ~~~~ CONTAINER VERSION: {container_tag} ~~~')
-        logger.debug(f'Use benchmark {benchmark_name} from container {container_source}/{container_name}. \n'
+        logger.debug(f'Use benchmark {benchmark_name} from container {self.container_source}/{container_name}. \n'
                      f'And container directory {self.config.container_dir}')
 
         # Pull the container from the singularity hub if the container is hosted online. If the container is stored
         # locally (e.g.for development) do not pull it.
-        if container_source is not None \
-                and any((s in container_source for s in ['shub', 'library', 'docker', 'oras', 'http'])):
+        if self.container_source is not None \
+                and any((s in self.container_source for s in ['shub', 'library', 'docker', 'oras', 'http'])):
 
             # Racing conditions: If a process is already loading the benchmark container, let all other processes wait.
             # Following https://github.com/dhellmann/oslo.concurrency/blob/master/openstack/common/lockutils.py
@@ -151,13 +155,13 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
             @lockutils.synchronized('not_thread_process_safe', external=True,
                                     lock_path=f'{self.config.cache_dir}/lock_{container_name}', delay=5)
             def download_container(container_dir, container_name, container_source, container_tag):
-                if not (container_dir / container_name_with_tag).exists():
+                if not (container_dir / self.container_name_with_tag).exists():
                     logger.debug('Going to pull the container from an online source.')
 
                     container_dir.mkdir(parents=True, exist_ok=True)
 
                     cmd = f'singularity pull --dir {self.config.container_dir} ' \
-                          f'--name {container_name_with_tag} '
+                          f'--name {self.container_name_with_tag} '
 
                     # Currently, we can't see the available container tags on gitlab. Therefore, we create for each
                     # "tag" a new entry in the registry. This might change in the future. But as long as we don't have
@@ -167,7 +171,7 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
                     else:
                         cmd += f'{container_source}/{container_name.lower()}:{container_tag}'
 
-                    logger.info(f'Start downloading the container {container_name_with_tag} from {container_source}. '
+                    logger.info(f'Start downloading the container {self.container_name_with_tag} from {container_source}. '
                                 'This may take several minutes.')
                     logger.debug(cmd)
                     subprocess.run(cmd, shell=True, check=True)
@@ -175,36 +179,40 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
                 else:
                     logger.debug('Skipping downloading the container. It is already downloaded.')
 
-            download_container(container_dir, container_name, container_source, container_tag)
+            download_container(self.container_dir, container_name, self.container_source, container_tag)
         else:
             logger.debug(f'Looking on the local filesystem for the container file, since container source was '
-                         f'either \'None\' or not a known address. Image Source: {container_source}')
+                         f'either \'None\' or not a known address. Image Source: {self.container_source}')
 
             # Make sure that the container can be found locally.
-            container_dir = Path(container_source)
+            self.container_dir = Path(self.container_source)
 
-            if not container_dir.exists():
+            if not self.container_dir.exists():
                 raise FileNotFoundError(f'Could not find the container on the local filesystem. The path '
-                                        f'{container_source} does not exist.'
+                                        f'{self.container_source} does not exist.'
                                         'Please either specify the full path to the container '
                                         'or the directory in which the container is, as well as '
                                         'the benchmark name and the container tag (default: latest).')
 
             # if the container source is the path to the container itself, we are going to use this container directly.
-            if container_dir.is_file():
-                container_name_with_tag = container_dir.name
-                container_dir = container_dir.parent
+            if self.container_dir.is_file():
+                self.container_name_with_tag = self.container_dir.name
+                self.container_dir = self.container_dir.parent
 
             # If the user specifies a container directory, search for the container name with (!) tag in it.
-            elif container_dir.is_dir():
-                assert (container_dir / container_name_with_tag).exists(), \
-                    f'Local container not found in {container_dir / container_name_with_tag}'
+            elif self.container_dir.is_dir():
+                assert (self.container_dir / self.container_name_with_tag).exists(), \
+                    f'Local container not found in {self.container_dir / self.container_name_with_tag}'
 
             else:
                 raise FileNotFoundError('The container source is neither a file nor a directory.'
-                                        f'container_source: {container_dir}')
+                                        f'self.container_source: {self.container_dir}')
 
             logger.debug('Image found on the local file system.')
+
+    def start_server(self, benchmark_name: str, container_name: str, container_source: Optional[str] = None,
+               container_tag: str = 'latest', env_str: Optional[str] = '', bind_str: Optional[str] = '',
+               gpu: Optional[bool] = False, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
 
         env_vars = {'HPOBENCH_DEBUG': log_level_str}
         if env_str.strip() != '':
@@ -225,8 +233,11 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
 
         gpu_opt = '--nv ' if gpu else ''  # Option for enabling GPU support
 
+        assert self.container_dir is not None and self.container_name_with_tag is not None
+
         cmd = f'singularity instance start {bind_options} {gpu_opt}' \
-              f'{container_dir / container_name_with_tag} {self.socket_id}'
+              f'{self.container_dir / self.container_name_with_tag} {self.socket_id}'
+        logger.debug(cmd)
         logger.debug(cmd)
 
         for num_tries in range(MAX_TRIES):
@@ -262,13 +273,17 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
         logger.debug(cmd)
         subprocess.Popen(cmd.split(), shell=False,
                          env={**os.environ, **{'SINGULARITYENV_HPOBENCH_DEBUG': log_level_str}})
+        logger.debug('Instance successfully started')
 
+    def connect_to_server(self):
         Pyro4.config.REQUIRE_EXPOSE = False
         # Generate Pyro 4 URI for connecting to client
         self.uri = f'PYRO:{self.socket_id}.unixsock@./u:' \
                    f'{self.config.socket_dir}/{self.socket_id}_unix.sock'
         self.benchmark = Pyro4.Proxy(self.uri)
+        logger.debug('Connected Proxy to benchmark')
 
+    def init_benchmark(self, rng, **kwargs):
         # Handle rng and other optional benchmark arguments
         kwargs_str = self._parse_kwargs(rng, **kwargs)
 
@@ -289,37 +304,6 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
 
             break
         logger.debug('Connected to container')
-
-    def _parse_kwargs(self, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
-        """ Helper function to parse the named keyword arguments to json str. """
-        if rng is not None:
-            kwargs['rng'] = rng
-        if 'latest' in kwargs:
-            del kwargs['latest']
-        kwargs_str = json.dumps(kwargs, indent=None, cls=BenchmarkEncoder)
-        return kwargs_str
-
-    def _parse_configuration(self, configuration: Union[CS.Configuration, Dict]) -> str:
-        if isinstance(configuration, CS.Configuration):
-            configuration = configuration.get_dictionary()
-        elif isinstance(configuration, dict):
-            configuration = configuration
-        else:
-            raise ValueError(f'Type of config not understood: {type(configuration)}')
-        c_str = json.dumps(configuration, indent=None, cls=BenchmarkEncoder)
-        return c_str
-
-    def _parse_fidelities(self, fidelity: Union[CS.Configuration, Dict, None] = None):
-        if fidelity is None:
-            fidelity = {}
-        elif isinstance(fidelity, CS.Configuration):
-            fidelity = fidelity.get_dictionary()
-        elif isinstance(fidelity, dict):
-            fidelity = fidelity
-        else:
-            raise ValueError(f'Type of fidelity not understood: {type(fidelity)}')
-        f_str = json.dumps(fidelity, indent=None, cls=BenchmarkEncoder)
-        return f_str
 
     def objective_function(self, configuration: Union[CS.Configuration, Dict],
                            fidelity: Union[Dict, CS.Configuration, None] = None,
@@ -433,7 +417,7 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
         """ Shutdown benchmark and stop container"""
         try:
             self.benchmark.shutdown()
-        except (ConnectionRefusedError, Pyro4.errors.CommunicationError, Pyro4.errors.ConnectionClosedError):
+        except (TypeError, ConnectionRefusedError, Pyro4.errors.CommunicationError, Pyro4.errors.ConnectionClosedError):
             pass
 
         # If the container is already closed, we dont want a error message here (-> DEVNULL)

--- a/hpobench/container/client_abstract_benchmark.py
+++ b/hpobench/container/client_abstract_benchmark.py
@@ -71,9 +71,9 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
 
         # connect to already running server if a socket_id is given. In this case, skip the init of
         # the benchmark
-        already_running = socket_id is not None
+        self.proxy_only = socket_id is not None
 
-        if not already_running:
+        if not self.proxy_only:
             self.socket_id = self._id_generator()
             self.load_benchmark(benchmark_name, container_name, container_source, container_tag, env_str, bind_str, gpu, rng,
                                 **kwargs)
@@ -439,7 +439,10 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
         return self.objective_function(configuration, **kwargs)['function_value']
 
     def __del__(self):
-        self._shutdown()
+        if not self.proxy_only:
+            self._shutdown()
+        else:
+            self.benchmark._pyroRelease()
 
     @staticmethod
     def _id_generator() -> str:

--- a/hpobench/container/client_abstract_benchmark.py
+++ b/hpobench/container/client_abstract_benchmark.py
@@ -114,7 +114,7 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
             When a `socket_id` is given, instead of creating a new container, connect only to the container that is
             reachable at `socket_id`. Make sure that a container is already running with the address `socket_id`.
 
-        kwargs : Dict
+        kwargs
             Optional benchmark parameters, such as a task_id for the XGBoostBenchmark
         """
 

--- a/hpobench/container/client_abstract_benchmark.py
+++ b/hpobench/container/client_abstract_benchmark.py
@@ -64,63 +64,67 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
     """
     def __init__(self, benchmark_name: str, container_name: str, container_source: Optional[str] = None,
                  container_tag: str = 'latest', env_str: Optional[str] = '', bind_str: Optional[str] = '',
-                 gpu: Optional[bool] = False, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
+                 gpu: Optional[bool] = False, rng: Union[np.random.RandomState, int, None] = None,
+                 socket_id=None, **kwargs):
 
-        self.socket_id = self._id_generator()
-        self._setup(benchmark_name, container_name, container_source, container_tag, env_str, bind_str, gpu, rng,
-                    **kwargs)
+        self.config = hpobench.config.config_file
 
-    def _setup(self, benchmark_name: str, container_name: str, container_source: Optional[str] = None,
+        # connect to already running server if a socket_id is given. In this case, skip the init of
+        # the benchmark
+        already_running = socket_id is not None
+
+        if not already_running:
+            self.socket_id = self._id_generator()
+            self.load_benchmark(benchmark_name, container_name, container_source, container_tag, env_str, bind_str, gpu, rng,
+                                **kwargs)
+            self.start_server(benchmark_name, container_name, container_source, container_tag, env_str, bind_str, gpu, rng,
+                              **kwargs)
+            self.connect_to_server()
+            self.init_benchmark(rng, **kwargs)
+        else:
+            self.socket_id = socket_id
+            self.connect_to_server()
+
+    def _parse_kwargs(self, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
+        """ Helper function to parse the named keyword arguments to json str. """
+        if rng is not None:
+            kwargs['rng'] = rng
+        if 'latest' in kwargs:
+            del kwargs['latest']
+        kwargs_str = json.dumps(kwargs, indent=None, cls=BenchmarkEncoder)
+        return kwargs_str
+
+    def _parse_configuration(self, configuration: Union[CS.Configuration, Dict]) -> str:
+        if isinstance(configuration, CS.Configuration):
+            configuration = configuration.get_dictionary()
+        elif isinstance(configuration, dict):
+            configuration = configuration
+        else:
+            raise ValueError(f'Type of config not understood: {type(configuration)}')
+        c_str = json.dumps(configuration, indent=None, cls=BenchmarkEncoder)
+        return c_str
+
+    def _parse_fidelities(self, fidelity: Union[CS.Configuration, Dict, None] = None):
+        if fidelity is None:
+            fidelity = {}
+        elif isinstance(fidelity, CS.Configuration):
+            fidelity = fidelity.get_dictionary()
+        elif isinstance(fidelity, dict):
+            fidelity = fidelity
+        else:
+            raise ValueError(f'Type of fidelity not understood: {type(fidelity)}')
+        f_str = json.dumps(fidelity, indent=None, cls=BenchmarkEncoder)
+        return f_str
+
+    def load_benchmark(self, benchmark_name: str, container_name: str, container_source: Optional[str] = None,
                container_tag: str = 'latest', env_str: Optional[str] = '', bind_str: Optional[str] = '',
                gpu: Optional[bool] = False, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
 
-        """ Initialization of the benchmark using container.
-
-        This setup function downloads the container from a defined source. The source is defined either in the
-        .hpobenchrc or in the its benchmark definition (hpobench/container/benchmarks/<type>/<name>). If an container
-        is already locally available, the local container is used. Then, the container is started and a connection
-        between the container and the client is established.
-
-        Parameters
-        ----------
-        benchmark_name: str
-            Class name of the benchmark to use. For example XGBoostBenchmark. This value is defined in the benchmark
-            definition (hpobench/container/benchmarks/<type>/<name>)
-        container_source : Optional[str]
-            Path to the container. Either local path or url to a hosting
-            platform, e.g. singularity hub.
-        container_tag : str
-            Singularity containers are specified by an address as well as a container tag. We use the tag as a version
-            number. By default the tag is set to `latest`, which then pulls the latest container from the container
-            source. The tag-versioning allows the users to rerun an experiment, which was performed with an older
-            container version. Take a look in the container_source to find the right tag to use.
-        container_name : str
-            name of the container. E.g. xgboost_benchmark. Specifying different container could be
-            useful to have multiple container for the same benchmark, if a tool like auto-sklearn is updated to a newer
-            version, and you want to compare its performance across its versions.
-            Also, a container can contain multiple benchmarks. Therefore, we have to define for each benchmark the
-            corresponding container name.
-        bind_str : Optional[str]
-            Defaults to ''. You can bind further directories into the container.
-            This string have the form src[:dest[:opts]].
-            For more information, see https://sylabs.io/guides/3.5/user-guide/bind_paths_and_mounts.html
-        env_str : Optional[str]
-            Defaults to ''. Sometimes you want to pass a parameter to your container. You can do this by setting some
-            environmental variables. The list should follow the form VAR1=VALUE1,VAR2=VALUE2,..
-            For more information, see
-            https://sylabs.io/guides/3.5/user-guide/environment_and_metadata.html#environment-overview
-        gpu : bool
-            If True, the container has access to the local cuda-drivers.
-            (Not tested)
-        """
-        # Create unique ID
-        self.config = hpobench.config.config_file
-
         # We can point to a different container source. See below.
-        container_source = container_source or self.config.container_source
-        container_dir = Path(self.config.container_dir)
+        self.container_source = container_source or self.config.container_source
+        self.container_dir = Path(self.config.container_dir)
 
-        if (container_source.startswith('oras://gitlab.tf.uni-freiburg.de:5050/muelleph/hpobench-registry')
+        if (self.container_source.startswith('oras://gitlab.tf.uni-freiburg.de:5050/muelleph/hpobench-registry')
                 and container_tag == 'latest'):
             assert 'latest' in kwargs, 'If the container is hosted on the gitlab registry, make sure that in the ' \
                                        'container init, the field \'latest\' is set.'
@@ -128,15 +132,15 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
             container_tag = kwargs['latest']
             logger.debug(f'Replace the tag \'latest\' with \'{container_tag}\'.')
 
-        container_name_with_tag = f'{container_name}_{container_tag}'
+        self.container_name_with_tag = f'{container_name}_{container_tag}'
         logger.info(f'~~~ HPOBENCH VERSION: {__version__} ~~~~ CONTAINER VERSION: {container_tag} ~~~')
-        logger.debug(f'Use benchmark {benchmark_name} from container {container_source}/{container_name}. \n'
+        logger.debug(f'Use benchmark {benchmark_name} from container {self.container_source}/{container_name}. \n'
                      f'And container directory {self.config.container_dir}')
 
         # Pull the container from the singularity hub if the container is hosted online. If the container is stored
         # locally (e.g.for development) do not pull it.
-        if container_source is not None \
-                and any((s in container_source for s in ['shub', 'library', 'docker', 'oras', 'http'])):
+        if self.container_source is not None \
+                and any((s in self.container_source for s in ['shub', 'library', 'docker', 'oras', 'http'])):
 
             # Racing conditions: If a process is already loading the benchmark container, let all other processes wait.
             # Following https://github.com/dhellmann/oslo.concurrency/blob/master/openstack/common/lockutils.py
@@ -151,13 +155,13 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
             @lockutils.synchronized('not_thread_process_safe', external=True,
                                     lock_path=f'{self.config.cache_dir}/lock_{container_name}', delay=5)
             def download_container(container_dir, container_name, container_source, container_tag):
-                if not (container_dir / container_name_with_tag).exists():
+                if not (container_dir / self.container_name_with_tag).exists():
                     logger.debug('Going to pull the container from an online source.')
 
                     container_dir.mkdir(parents=True, exist_ok=True)
 
                     cmd = f'singularity pull --dir {self.config.container_dir} ' \
-                          f'--name {container_name_with_tag} '
+                          f'--name {self.container_name_with_tag} '
 
                     # Currently, we can't see the available container tags on gitlab. Therefore, we create for each
                     # "tag" a new entry in the registry. This might change in the future. But as long as we don't have
@@ -167,7 +171,7 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
                     else:
                         cmd += f'{container_source}/{container_name.lower()}:{container_tag}'
 
-                    logger.info(f'Start downloading the container {container_name_with_tag} from {container_source}. '
+                    logger.info(f'Start downloading the container {self.container_name_with_tag} from {container_source}. '
                                 'This may take several minutes.')
                     logger.debug(cmd)
                     subprocess.run(cmd, shell=True, check=True)
@@ -175,36 +179,40 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
                 else:
                     logger.debug('Skipping downloading the container. It is already downloaded.')
 
-            download_container(container_dir, container_name, container_source, container_tag)
+            download_container(self.container_dir, container_name, self.container_source, container_tag)
         else:
             logger.debug(f'Looking on the local filesystem for the container file, since container source was '
-                         f'either \'None\' or not a known address. Image Source: {container_source}')
+                         f'either \'None\' or not a known address. Image Source: {self.container_source}')
 
             # Make sure that the container can be found locally.
-            container_dir = Path(container_source)
+            self.container_dir = Path(self.container_source)
 
-            if not container_dir.exists():
+            if not self.container_dir.exists():
                 raise FileNotFoundError(f'Could not find the container on the local filesystem. The path '
-                                        f'{container_source} does not exist.'
+                                        f'{self.container_source} does not exist.'
                                         'Please either specify the full path to the container '
                                         'or the directory in which the container is, as well as '
                                         'the benchmark name and the container tag (default: latest).')
 
             # if the container source is the path to the container itself, we are going to use this container directly.
-            if container_dir.is_file():
-                container_name_with_tag = container_dir.name
-                container_dir = container_dir.parent
+            if self.container_dir.is_file():
+                self.container_name_with_tag = self.container_dir.name
+                self.container_dir = self.container_dir.parent
 
             # If the user specifies a container directory, search for the container name with (!) tag in it.
-            elif container_dir.is_dir():
-                assert (container_dir / container_name_with_tag).exists(), \
-                    f'Local container not found in {container_dir / container_name_with_tag}'
+            elif self.container_dir.is_dir():
+                assert (self.container_dir / self.container_name_with_tag).exists(), \
+                    f'Local container not found in {self.container_dir / self.container_name_with_tag}'
 
             else:
                 raise FileNotFoundError('The container source is neither a file nor a directory.'
-                                        f'container_source: {container_dir}')
+                                        f'self.container_source: {self.container_dir}')
 
             logger.debug('Image found on the local file system.')
+
+    def start_server(self, benchmark_name: str, container_name: str, container_source: Optional[str] = None,
+               container_tag: str = 'latest', env_str: Optional[str] = '', bind_str: Optional[str] = '',
+               gpu: Optional[bool] = False, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
 
         env_vars = {'HPOBENCH_DEBUG': log_level_str}
         if env_str.strip() != '':
@@ -225,8 +233,11 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
 
         gpu_opt = '--nv ' if gpu else ''  # Option for enabling GPU support
 
+        assert self.container_dir is not None and self.container_name_with_tag is not None
+
         cmd = f'singularity instance start {bind_options} {gpu_opt}' \
-              f'{container_dir / container_name_with_tag} {self.socket_id}'
+              f'{self.container_dir / self.container_name_with_tag} {self.socket_id}'
+        logger.debug(cmd)
         logger.debug(cmd)
 
         for num_tries in range(MAX_TRIES):
@@ -263,13 +274,17 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
         logger.debug(cmd)
         subprocess.Popen(cmd.split(), shell=False,
                          env={**os.environ, **{'SINGULARITYENV_HPOBENCH_DEBUG': log_level_str}})
+        logger.debug('Instance successfully started')
 
+    def connect_to_server(self):
         Pyro4.config.REQUIRE_EXPOSE = False
         # Generate Pyro 4 URI for connecting to client
         self.uri = f'PYRO:{self.socket_id}.unixsock@./u:' \
                    f'{self.config.socket_dir}/{self.socket_id}_unix.sock'
         self.benchmark = Pyro4.Proxy(self.uri)
+        logger.debug('Connected Proxy to benchmark')
 
+    def init_benchmark(self, rng, **kwargs):
         # Handle rng and other optional benchmark arguments
         kwargs_str = self._parse_kwargs(rng, **kwargs)
 
@@ -290,37 +305,6 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
 
             break
         logger.debug('Connected to container')
-
-    def _parse_kwargs(self, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
-        """ Helper function to parse the named keyword arguments to json str. """
-        if rng is not None:
-            kwargs['rng'] = rng
-        if 'latest' in kwargs:
-            del kwargs['latest']
-        kwargs_str = json.dumps(kwargs, indent=None, cls=BenchmarkEncoder)
-        return kwargs_str
-
-    def _parse_configuration(self, configuration: Union[CS.Configuration, Dict]) -> str:
-        if isinstance(configuration, CS.Configuration):
-            configuration = configuration.get_dictionary()
-        elif isinstance(configuration, dict):
-            configuration = configuration
-        else:
-            raise ValueError(f'Type of config not understood: {type(configuration)}')
-        c_str = json.dumps(configuration, indent=None, cls=BenchmarkEncoder)
-        return c_str
-
-    def _parse_fidelities(self, fidelity: Union[CS.Configuration, Dict, None] = None):
-        if fidelity is None:
-            fidelity = {}
-        elif isinstance(fidelity, CS.Configuration):
-            fidelity = fidelity.get_dictionary()
-        elif isinstance(fidelity, dict):
-            fidelity = fidelity
-        else:
-            raise ValueError(f'Type of fidelity not understood: {type(fidelity)}')
-        f_str = json.dumps(fidelity, indent=None, cls=BenchmarkEncoder)
-        return f_str
 
     def objective_function(self, configuration: Union[CS.Configuration, Dict],
                            fidelity: Union[Dict, CS.Configuration, None] = None,
@@ -434,7 +418,7 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
         """ Shutdown benchmark and stop container"""
         try:
             self.benchmark.shutdown()
-        except (ConnectionRefusedError, Pyro4.errors.CommunicationError, Pyro4.errors.ConnectionClosedError):
+        except (TypeError, ConnectionRefusedError, Pyro4.errors.CommunicationError, Pyro4.errors.ConnectionClosedError):
             pass
 
         try:

--- a/hpobench/container/client_abstract_benchmark.py
+++ b/hpobench/container/client_abstract_benchmark.py
@@ -75,10 +75,10 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
 
         if not self.proxy_only:
             self.socket_id = self._id_generator()
-            self.load_benchmark(benchmark_name, container_name, container_source, container_tag, env_str, bind_str, gpu, rng,
-                                **kwargs)
-            self.start_server(benchmark_name, container_name, container_source, container_tag, env_str, bind_str, gpu, rng,
-                              **kwargs)
+
+            self.load_benchmark(benchmark_name=benchmark_name, container_name=container_name,
+                                container_source=container_source, container_tag=container_tag, **kwargs)
+            self.start_server(benchmark_name=benchmark_name, env_str=env_str, bind_str=bind_str, gpu=gpu)
             self.connect_to_server()
             self.init_benchmark(rng, **kwargs)
         else:
@@ -117,8 +117,7 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
         return f_str
 
     def load_benchmark(self, benchmark_name: str, container_name: str, container_source: Optional[str] = None,
-               container_tag: str = 'latest', env_str: Optional[str] = '', bind_str: Optional[str] = '',
-               gpu: Optional[bool] = False, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
+                       container_tag: str = 'latest', **kwargs):
 
         # We can point to a different container source. See below.
         self.container_source = container_source or self.config.container_source
@@ -171,8 +170,8 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
                     else:
                         cmd += f'{container_source}/{container_name.lower()}:{container_tag}'
 
-                    logger.info(f'Start downloading the container {self.container_name_with_tag} from {container_source}. '
-                                'This may take several minutes.')
+                    logger.info(f'Start downloading the container {self.container_name_with_tag} '
+                                f'from {container_source}. This may take several minutes.')
                     logger.debug(cmd)
                     subprocess.run(cmd, shell=True, check=True)
                     time.sleep(1)
@@ -210,9 +209,8 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
 
             logger.debug('Image found on the local file system.')
 
-    def start_server(self, benchmark_name: str, container_name: str, container_source: Optional[str] = None,
-               container_tag: str = 'latest', env_str: Optional[str] = '', bind_str: Optional[str] = '',
-               gpu: Optional[bool] = False, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
+    def start_server(self, benchmark_name: str, env_str: Optional[str] = '', bind_str: Optional[str] = '',
+                     gpu: Optional[bool] = False):
 
         env_vars = {'HPOBENCH_DEBUG': log_level_str}
         if env_str.strip() != '':

--- a/hpobench/container/client_abstract_benchmark.py
+++ b/hpobench/container/client_abstract_benchmark.py
@@ -483,7 +483,6 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
         try:
             self.benchmark.shutdown()
         except (TypeError, ConnectionRefusedError, Pyro4.errors.CommunicationError, Pyro4.errors.ConnectionClosedError):
-        except (TypeError, ConnectionRefusedError, Pyro4.errors.CommunicationError, Pyro4.errors.ConnectionClosedError):
             pass
 
         try:

--- a/hpobench/container/client_abstract_benchmark.py
+++ b/hpobench/container/client_abstract_benchmark.py
@@ -71,9 +71,9 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
 
         # connect to already running server if a socket_id is given. In this case, skip the init of
         # the benchmark
-        already_running = socket_id is not None
+        self.proxy_only = socket_id is not None
 
-        if not already_running:
+        if not self.proxy_only:
             self.socket_id = self._id_generator()
             self.load_benchmark(benchmark_name, container_name, container_source, container_tag, env_str, bind_str, gpu, rng,
                                 **kwargs)
@@ -433,7 +433,10 @@ class AbstractBenchmarkClient(metaclass=abc.ABCMeta):
         return self.objective_function(configuration, **kwargs)['function_value']
 
     def __del__(self):
-        self._shutdown()
+        if not self.proxy_only:
+            self._shutdown()
+        else:
+            self.benchmark._pyroRelease()
 
     @staticmethod
     def _id_generator() -> str:

--- a/hpobench/container/recipes/Singularity.template
+++ b/hpobench/container/recipes/Singularity.template
@@ -24,7 +24,7 @@ VERSION v0.0.1
     && echo "Please never push a recipe that checks out any other branch than development or master" \
     && git checkout development \
     && echo "Here you can install extra requirements additional to singularity" \
-    && pip install . \
+    && pip install .[<new_benchmark>] \
     && echo "Please don't touch the following lines"
     && cd / \
     && mkdir /var/lib/hpobench/ \
@@ -35,4 +35,4 @@ VERSION v0.0.1
     echo "Finally, please change the benchmark in the runscript to point to your benchmark"
 
 %runscript
-    python -s /home/HPOBench/hpobench/container/server_abstract_benchmark.py <type>.new_benchmark_file $@
+    python -s /home/HPOBench/hpobench/container/server_abstract_benchmark.py <type>.<new_benchmark> $@


### PR DESCRIPTION
This PR splits up the server startup procedure. 

Now, we can start a benchmark and later connect to this benchmark instance without starting a new instance. 

To connect to an instance without starting a new instance call the Benchmark Constructor with the socket id. 

```
benchmark = Benchmark(socket_id=<socket_id>) 
```

The socket id can be found either from the terminal: 

```
singularity instance list
```

or by accessing the benchmarks attribute `benchmark.socket_id` 