### PR TITLE
NAS201 + TabBenchmarks: New Fidelity Spaces

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,12 @@
 # 0.0.10
   * Cartpole Benchmark Version 0.0.4:
     Fix: Pass the hp `entropy_regularization` to the PPO Agent. 
-    Set the lower limit of an hyperparameter from 0 to 10e-7 (0 is invalid.)
-    
+    Set the lower limit of an hyperparameter from 0 to 10e-7 (0 is invalid.)K
+  * Tabular Benchmark (NAS) Version 0.0.5 + NAS201 Version 0.0.5:
+    We add for each benchmark in the tabular nas benchmarks and the NAS201 a new version with a modified fidelity space. 
+    These new benchmarks implement the fidelity space used in the experiments of DEHB. 
+    We introduce a new benchmark version for both benchmark classes. The "old" benchmarks remain unchanged.  
+  
 # 0.0.9
   * Add new Benchmarks: Tabular Benchmarks.
     Provided by @Neeratyoy. 

--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,11 @@
 # 0.0.10
   * Cartpole Benchmark Version 0.0.4:
     Fix: Pass the hp `entropy_regularization` to the PPO Agent. 
-    Set the lower limit of an hyperparameter from 0 to 10e-7 (0 is invalid.)K
+    Increase the lower limit of `likelihood_ratio_clipping` from 0 to 10e-7 (0 is invalid.)
   * Tabular Benchmark (NAS) Version 0.0.5 + NAS201 Version 0.0.5:
-    We add for each benchmark in the tabular nas benchmarks and the NAS201 a new version with a modified fidelity space. 
-    These new benchmarks implement the fidelity space used in the experiments of DEHB. 
-    We introduce a new benchmark version for both benchmark classes. The "old" benchmarks remain unchanged.  
+    We add for each benchmark in nas/tabular_benchmarks and nas/nasbench_201 a new benchmark class with a modified fidelity space. The new benchmark are called _Original_, e.g. _SliceLocalizationBenchmarkOriginal_ compared to _SliceLocalizationBenchmark_
+    These new benchmarks have the same fidelity space as used in previous experiments by [DEHB](https://ml.informatik.uni-freiburg.de/wp-content/uploads/papers/21-IJCAI-DEHB.pdf) and [BOHB](http://proceedings.mlr.press/v80/falkner18a/falkner18a.pdf).
+    Specifically, we increase the lowest fidelity from 1 to 3 for nas/tabular_benchmarks and from 1 to 12 for nas/nasbench_201. The upper fidelity and the old benchmarks remain unchanged.
   
 # 0.0.9
   * Add new Benchmarks: Tabular Benchmarks.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # 0.0.10
-
+  * Cartpole Benchmark Version 0.0.4:
+    Fix: Pass the hp `entropy_regularization` to the PPO Agent. 
+    Set the lower limit of an hyperparameter from 0 to 10e-7 (0 is invalid.)
+    
 # 0.0.9
   * Add new Benchmarks: Tabular Benchmarks.
     Provided by @Neeratyoy. 

--- a/hpobench/benchmarks/nas/nasbench_201.py
+++ b/hpobench/benchmarks/nas/nasbench_201.py
@@ -489,7 +489,7 @@ class ImageNetNasBench201Benchmark(NasBench201BaseBenchmark):
         super(ImageNetNasBench201Benchmark, self).__init__(dataset='ImageNet16-120', rng=rng, **kwargs)
 
 
-class _NasBench201OriginalBaseBenchmark(NasBench201BaseBenchmark):
+class _NasBench201BaseBenchmarkOriginal(NasBench201BaseBenchmark):
 
     @staticmethod
     def get_fidelity_space(seed: Union[int, None] = None) -> CS.ConfigurationSpace:
@@ -535,19 +535,19 @@ class _NasBench201OriginalBaseBenchmark(NasBench201BaseBenchmark):
         return meta_information
 
 
-class Cifar10ValidNasBench201BenchmarkOriginal(NasBench201BaseBenchmark):
+class Cifar10ValidNasBench201BenchmarkOriginal(_NasBench201BaseBenchmarkOriginal):
 
     def __init__(self, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
         super(Cifar10ValidNasBench201BenchmarkOriginal, self).__init__(dataset='cifar10-valid', rng=rng, **kwargs)
 
 
-class Cifar100NasBench201BenchmarkOriginal(NasBench201BaseBenchmark):
+class Cifar100NasBench201BenchmarkOriginal(_NasBench201BaseBenchmarkOriginal):
 
     def __init__(self, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
         super(Cifar100NasBench201BenchmarkOriginal, self).__init__(dataset='cifar100', rng=rng, **kwargs)
 
 
-class ImageNetNasBench201BenchmarkOriginal(NasBench201BaseBenchmark):
+class ImageNetNasBench201BenchmarkOriginal(_NasBench201BaseBenchmarkOriginal):
 
     def __init__(self, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
         super(ImageNetNasBench201BenchmarkOriginal, self).__init__(dataset='ImageNet16-120', rng=rng, **kwargs)

--- a/hpobench/benchmarks/nas/nasbench_201.py
+++ b/hpobench/benchmarks/nas/nasbench_201.py
@@ -27,6 +27,10 @@ https://github.com/D-X-Y/AutoDL-Projects/blob/master/docs/NAS-Bench-201.md
 
 Changelog:
 ==========
+0.0.5
+* Add for each benchmark a new one with a different fidelity space.
+  The new fidelity space corresponds to the fidelity space in the DEHB paper.
+
 0.0.4
 * New container release due to a general change in the communication between container and HPOBench.
   Works with HPOBench >= v0.0.8
@@ -53,7 +57,7 @@ import hpobench.util.rng_helper as rng_helper
 from hpobench.abstract_benchmark import AbstractBenchmark
 from hpobench.util.data_manager import NASBench_201Data
 
-__version__ = '0.0.4'
+__version__ = '0.0.5'
 MAX_NODES = 4
 
 logger = logging.getLogger('NASBENCH201')
@@ -483,3 +487,73 @@ class ImageNetNasBench201Benchmark(NasBench201BaseBenchmark):
 
     def __init__(self, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
         super(ImageNetNasBench201Benchmark, self).__init__(dataset='ImageNet16-120', rng=rng, **kwargs)
+
+
+class _NasBench201OriginalBaseBenchmark(NasBench201BaseBenchmark):
+
+    @staticmethod
+    def get_fidelity_space(seed: Union[int, None] = None) -> CS.ConfigurationSpace:
+        """
+        Creates a ConfigSpace.ConfigurationSpace containing all fidelity parameters for
+        the NAS Benchmark 201.
+
+        This fidelity space differs from the one above in its lower bound.
+        The benchmark above enables the user to access the entire dataset while this one is meant to reproduce the
+        experiments from DEHB (TODO LINK).
+
+        Fidelities:
+        epoch: int
+            The loss / accuracy at `epoch`.
+
+        Parameters
+        ----------
+        seed : int, None
+            Fixing the seed for the ConfigSpace.ConfigurationSpace
+
+        Returns
+        -------
+        ConfigSpace.ConfigurationSpace
+        """
+        seed = seed if seed is not None else np.random.randint(1, 100000)
+        fidel_space = CS.ConfigurationSpace(seed=seed)
+
+        # We use here the lower bound of 4 instead of 1.
+        fidel_space.add_hyperparameters([
+            CS.UniformIntegerHyperparameter('epoch', lower=4, upper=200, default_value=200)
+        ])
+
+        return fidel_space
+
+    @staticmethod
+    def get_meta_information() -> Dict:
+        """ Returns the meta information for the benchmark """
+        meta_information = NasBench201BaseBenchmark.get_meta_information()
+        meta_information['note'] = 'This version of the benchmark implements the fidelity space defined in the DEHB' \
+                                   'paper. See TODO LINK. '
+        return meta_information
+
+
+class Cifar10ValidNasBench201OriginalBenchmark(NasBench201BaseBenchmark):
+
+    def __init__(self, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
+        super(Cifar10ValidNasBench201OriginalBenchmark, self).__init__(dataset='cifar10-valid', rng=rng, **kwargs)
+
+
+class Cifar100NasBench201OriginalBenchmark(NasBench201BaseBenchmark):
+
+    def __init__(self, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
+        super(Cifar100NasBench201OriginalBenchmark, self).__init__(dataset='cifar100', rng=rng, **kwargs)
+
+
+class ImageNetNasBench201OriginalBenchmark(NasBench201BaseBenchmark):
+
+    def __init__(self, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
+        super(ImageNetNasBench201OriginalBenchmark, self).__init__(dataset='ImageNet16-120', rng=rng, **kwargs)
+
+
+__all__ = ["Cifar10ValidNasBench201Benchmark",
+           "Cifar100NasBench201Benchmark",
+           "ImageNetNasBench201Benchmark",
+           "Cifar10ValidNasBench201OriginalBenchmark",
+           "Cifar100NasBench201OriginalBenchmark",
+           "ImageNetNasBench201OriginalBenchmark"]

--- a/hpobench/benchmarks/nas/nasbench_201.py
+++ b/hpobench/benchmarks/nas/nasbench_201.py
@@ -498,8 +498,9 @@ class _NasBench201OriginalBaseBenchmark(NasBench201BaseBenchmark):
         the NAS Benchmark 201.
 
         This fidelity space differs from the one above in its lower bound.
-        The benchmark above enables the user to access the entire dataset while this one is meant to reproduce the
-        experiments from DEHB (TODO LINK).
+        The benchmark above enables the user to access the entire dataset, while this one reproduces the
+        experiments from DEHB
+        [DEHB](https://github.com/automl/DEHB/tree/937dd5cf48e79f6d587ea2ff408cb5ad9a8dce46/dehb/examples)
 
         Fidelities:
         epoch: int
@@ -528,8 +529,9 @@ class _NasBench201OriginalBaseBenchmark(NasBench201BaseBenchmark):
     def get_meta_information() -> Dict:
         """ Returns the meta information for the benchmark """
         meta_information = NasBench201BaseBenchmark.get_meta_information()
-        meta_information['note'] = 'This version of the benchmark implements the fidelity space defined in the DEHB' \
-                                   'paper. See TODO LINK. '
+        meta_information['note'] = \
+            'This version of the benchmark implements the fidelity space defined in the DEHB paper.' \
+            'See [DEHB](https://github.com/automl/DEHB/tree/937dd5cf48e79f6d587ea2ff408cb5ad9a8dce46/dehb/examples)'
         return meta_information
 
 

--- a/hpobench/benchmarks/nas/nasbench_201.py
+++ b/hpobench/benchmarks/nas/nasbench_201.py
@@ -535,27 +535,27 @@ class _NasBench201OriginalBaseBenchmark(NasBench201BaseBenchmark):
         return meta_information
 
 
-class Cifar10ValidNasBench201OriginalBenchmark(NasBench201BaseBenchmark):
+class Cifar10ValidNasBench201BenchmarkOriginal(NasBench201BaseBenchmark):
 
     def __init__(self, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
-        super(Cifar10ValidNasBench201OriginalBenchmark, self).__init__(dataset='cifar10-valid', rng=rng, **kwargs)
+        super(Cifar10ValidNasBench201BenchmarkOriginal, self).__init__(dataset='cifar10-valid', rng=rng, **kwargs)
 
 
-class Cifar100NasBench201OriginalBenchmark(NasBench201BaseBenchmark):
-
-    def __init__(self, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
-        super(Cifar100NasBench201OriginalBenchmark, self).__init__(dataset='cifar100', rng=rng, **kwargs)
-
-
-class ImageNetNasBench201OriginalBenchmark(NasBench201BaseBenchmark):
+class Cifar100NasBench201BenchmarkOriginal(NasBench201BaseBenchmark):
 
     def __init__(self, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
-        super(ImageNetNasBench201OriginalBenchmark, self).__init__(dataset='ImageNet16-120', rng=rng, **kwargs)
+        super(Cifar100NasBench201BenchmarkOriginal, self).__init__(dataset='cifar100', rng=rng, **kwargs)
+
+
+class ImageNetNasBench201BenchmarkOriginal(NasBench201BaseBenchmark):
+
+    def __init__(self, rng: Union[np.random.RandomState, int, None] = None, **kwargs):
+        super(ImageNetNasBench201BenchmarkOriginal, self).__init__(dataset='ImageNet16-120', rng=rng, **kwargs)
 
 
 __all__ = ["Cifar10ValidNasBench201Benchmark",
            "Cifar100NasBench201Benchmark",
            "ImageNetNasBench201Benchmark",
-           "Cifar10ValidNasBench201OriginalBenchmark",
-           "Cifar100NasBench201OriginalBenchmark",
-           "ImageNetNasBench201OriginalBenchmark"]
+           "Cifar10ValidNasBench201BenchmarkOriginal",
+           "Cifar100NasBench201BenchmarkOriginal",
+           "ImageNetNasBench201BenchmarkOriginal"]

--- a/hpobench/benchmarks/nas/nasbench_201.py
+++ b/hpobench/benchmarks/nas/nasbench_201.py
@@ -519,7 +519,7 @@ class _NasBench201OriginalBaseBenchmark(NasBench201BaseBenchmark):
 
         # We use here the lower bound of 4 instead of 1.
         fidel_space.add_hyperparameters([
-            CS.UniformIntegerHyperparameter('epoch', lower=4, upper=200, default_value=200)
+            CS.UniformIntegerHyperparameter('epoch', lower=12, upper=200, default_value=200)
         ])
 
         return fidel_space

--- a/hpobench/benchmarks/nas/tabular_benchmarks.py
+++ b/hpobench/benchmarks/nas/tabular_benchmarks.py
@@ -327,7 +327,7 @@ class _FCNetBaseOriginalBenchmark(FCNetBaseBenchmark):
         fidel_space = CS.ConfigurationSpace(seed=seed)
 
         fidel_space.add_hyperparameters([
-            CS.UniformIntegerHyperparameter('budget', lower=4, upper=100, default_value=100)
+            CS.UniformIntegerHyperparameter('budget', lower=3, upper=100, default_value=100)
         ])
 
         return fidel_space

--- a/hpobench/benchmarks/nas/tabular_benchmarks.py
+++ b/hpobench/benchmarks/nas/tabular_benchmarks.py
@@ -311,8 +311,9 @@ class _FCNetBaseOriginalBenchmark(FCNetBaseBenchmark):
     def get_fidelity_space(seed: Union[int, None] = None) -> CS.ConfigurationSpace:
         """
         This fidelity space differs from the one above in its lower bound.
-        The benchmark above enables the user to access the entire dataset while this one is meant to reproduce the
-        experiments from DEHB (TODO LINK).
+        The benchmark above enables the user to access the entire dataset, while this one reproduces the
+        experiments from DEHB
+        [DEHB](https://github.com/automl/DEHB/tree/937dd5cf48e79f6d587ea2ff408cb5ad9a8dce46/dehb/examples)
 
         Parameters
         ----------
@@ -336,8 +337,9 @@ class _FCNetBaseOriginalBenchmark(FCNetBaseBenchmark):
     def get_meta_information() -> Dict:
         """ Returns the meta information for the benchmark """
         meta_information = FCNetBaseBenchmark.get_meta_information()
-        meta_information['note'] = 'This version of the benchmark implements the fidelity space defined in the DEHB' \
-                                   'paper. See TODO LINK. '
+        meta_information['note'] = \
+            'This version of the benchmark implements the fidelity space defined in the DEHB paper. ' \
+            'See [DEHB](https://github.com/automl/DEHB/tree/937dd5cf48e79f6d587ea2ff408cb5ad9a8dce46/dehb/examples)'
         return meta_information
 
 

--- a/hpobench/benchmarks/nas/tabular_benchmarks.py
+++ b/hpobench/benchmarks/nas/tabular_benchmarks.py
@@ -305,7 +305,7 @@ class ParkinsonsTelemonitoringBenchmark(FCNetBaseBenchmark):
                                                                 **kwargs)
 
 
-class _FCNetBaseOriginalBenchmark(FCNetBaseBenchmark):
+class _FCNetBaseBenchmarkOriginal(FCNetBaseBenchmark):
 
     @staticmethod
     def get_fidelity_space(seed: Union[int, None] = None) -> CS.ConfigurationSpace:
@@ -343,7 +343,7 @@ class _FCNetBaseOriginalBenchmark(FCNetBaseBenchmark):
         return meta_information
 
 
-class SliceLocalizationOriginalBenchmark(_FCNetBaseOriginalBenchmark):
+class SliceLocalizationBenchmarkOriginal(_FCNetBaseBenchmarkOriginal):
 
     def __init__(self, data_path: Union[Path, str, None] = None,
                  rng: Union[np.random.RandomState, int, None] = None, **kwargs):
@@ -353,11 +353,11 @@ class SliceLocalizationOriginalBenchmark(_FCNetBaseOriginalBenchmark):
         from tabular_benchmarks import FCNetSliceLocalizationBenchmark
 
         benchmark = FCNetSliceLocalizationBenchmark(data_dir=str(data_path))
-        super(SliceLocalizationOriginalBenchmark, self).__init__(benchmark=benchmark, data_path=data_path, rng=rng,
+        super(SliceLocalizationBenchmarkOriginal, self).__init__(benchmark=benchmark, data_path=data_path, rng=rng,
                                                                  **kwargs)
 
 
-class ProteinStructureOriginalBenchmark(_FCNetBaseOriginalBenchmark):
+class ProteinStructureBenchmarkOriginal(_FCNetBaseBenchmarkOriginal):
 
     def __init__(self, data_path: Union[Path, str, None] = None,
                  rng: Union[np.random.RandomState, int, None] = None, **kwargs):
@@ -366,11 +366,11 @@ class ProteinStructureOriginalBenchmark(_FCNetBaseOriginalBenchmark):
 
         from tabular_benchmarks import FCNetProteinStructureBenchmark
         benchmark = FCNetProteinStructureBenchmark(data_dir=str(data_path))
-        super(ProteinStructureOriginalBenchmark, self).__init__(benchmark=benchmark, data_path=data_path, rng=rng,
+        super(ProteinStructureBenchmarkOriginal, self).__init__(benchmark=benchmark, data_path=data_path, rng=rng,
                                                                 **kwargs)
 
 
-class NavalPropulsionOriginalBenchmark(_FCNetBaseOriginalBenchmark):
+class NavalPropulsionBenchmarkOriginal(_FCNetBaseBenchmarkOriginal):
 
     def __init__(self, data_path: Union[Path, str, None] = None,
                  rng: Union[np.random.RandomState, int, None] = None, **kwargs):
@@ -379,11 +379,11 @@ class NavalPropulsionOriginalBenchmark(_FCNetBaseOriginalBenchmark):
 
         from tabular_benchmarks import FCNetNavalPropulsionBenchmark
         benchmark = FCNetNavalPropulsionBenchmark(data_dir=str(data_path))
-        super(NavalPropulsionOriginalBenchmark, self).__init__(benchmark=benchmark, data_path=data_path, rng=rng,
+        super(NavalPropulsionBenchmarkOriginal, self).__init__(benchmark=benchmark, data_path=data_path, rng=rng,
                                                                **kwargs)
 
 
-class ParkinsonsTelemonitoringOriginalBenchmark(_FCNetBaseOriginalBenchmark):
+class ParkinsonsTelemonitoringBenchmarkOriginal(_FCNetBaseBenchmarkOriginal):
 
     def __init__(self, data_path: Union[Path, str, None] = None,
                  rng: Union[np.random.RandomState, int, None] = None, **kwargs):
@@ -392,11 +392,11 @@ class ParkinsonsTelemonitoringOriginalBenchmark(_FCNetBaseOriginalBenchmark):
 
         from tabular_benchmarks import FCNetParkinsonsTelemonitoringBenchmark
         benchmark = FCNetParkinsonsTelemonitoringBenchmark(data_dir=str(data_path))
-        super(ParkinsonsTelemonitoringOriginalBenchmark, self).__init__(benchmark=benchmark, data_path=data_path,
+        super(ParkinsonsTelemonitoringBenchmarkOriginal, self).__init__(benchmark=benchmark, data_path=data_path,
                                                                         rng=rng, **kwargs)
 
 
-__all__ = ["SliceLocalizationBenchmark", "SliceLocalizationOriginalBenchmark",
-           "ProteinStructureBenchmark", "ProteinStructureOriginalBenchmark",
-           "NavalPropulsionBenchmark", "NavalPropulsionOriginalBenchmark",
-           "ParkinsonsTelemonitoringBenchmark", "ParkinsonsTelemonitoringOriginalBenchmark"]
+__all__ = ["SliceLocalizationBenchmark", "SliceLocalizationBenchmarkOriginal",
+           "ProteinStructureBenchmark", "ProteinStructureBenchmarkOriginal",
+           "NavalPropulsionBenchmark", "NavalPropulsionBenchmarkOriginal",
+           "ParkinsonsTelemonitoringBenchmark", "ParkinsonsTelemonitoringBenchmarkOriginal"]

--- a/hpobench/benchmarks/nas/tabular_benchmarks.py
+++ b/hpobench/benchmarks/nas/tabular_benchmarks.py
@@ -30,6 +30,10 @@ python setup.py install
 
 Changelog:
 ==========
+0.0.5
+* Add for each benchmark a new one with a different fidelity space.
+  The new fidelity space corresponds to the fidelity space in the DEHB paper.
+
 0.0.4
 * New container release due to a general change in the communication between container and HPOBench.
   Works with HPOBench >= v0.0.8
@@ -57,7 +61,7 @@ from tabular_benchmarks.fcnet_benchmark import FCNetBenchmark
 import hpobench.util.rng_helper as rng_helper
 from hpobench.abstract_benchmark import AbstractBenchmark
 
-__version__ = '0.0.4'
+__version__ = '0.0.5'
 logger = logging.getLogger('TabularBenchmark')
 
 
@@ -299,3 +303,98 @@ class ParkinsonsTelemonitoringBenchmark(FCNetBaseBenchmark):
         benchmark = FCNetParkinsonsTelemonitoringBenchmark(data_dir=str(data_path))
         super(ParkinsonsTelemonitoringBenchmark, self).__init__(benchmark=benchmark, data_path=data_path, rng=rng,
                                                                 **kwargs)
+
+
+class _FCNetBaseOriginalBenchmark(FCNetBaseBenchmark):
+
+    @staticmethod
+    def get_fidelity_space(seed: Union[int, None] = None) -> CS.ConfigurationSpace:
+        """
+        This fidelity space differs from the one above in its lower bound.
+        The benchmark above enables the user to access the entire dataset while this one is meant to reproduce the
+        experiments from DEHB (TODO LINK).
+
+        Parameters
+        ----------
+        seed : int, None
+            Fixing the seed for the ConfigSpace.ConfigurationSpace
+
+        Returns
+        -------
+        ConfigSpace.ConfigurationSpace
+        """
+        seed = seed if seed is not None else np.random.randint(1, 100000)
+        fidel_space = CS.ConfigurationSpace(seed=seed)
+
+        fidel_space.add_hyperparameters([
+            CS.UniformIntegerHyperparameter('budget', lower=4, upper=100, default_value=100)
+        ])
+
+        return fidel_space
+
+    @staticmethod
+    def get_meta_information() -> Dict:
+        """ Returns the meta information for the benchmark """
+        meta_information = FCNetBaseBenchmark.get_meta_information()
+        meta_information['note'] = 'This version of the benchmark implements the fidelity space defined in the DEHB' \
+                                   'paper. See TODO LINK. '
+        return meta_information
+
+
+class SliceLocalizationOriginalBenchmark(_FCNetBaseOriginalBenchmark):
+
+    def __init__(self, data_path: Union[Path, str, None] = None,
+                 rng: Union[np.random.RandomState, int, None] = None, **kwargs):
+        from hpobench import config_file
+        data_path = Path(data_path) if data_path is not None else config_file.data_dir / 'fcnet_tabular_benchmarks'
+
+        from tabular_benchmarks import FCNetSliceLocalizationBenchmark
+
+        benchmark = FCNetSliceLocalizationBenchmark(data_dir=str(data_path))
+        super(SliceLocalizationOriginalBenchmark, self).__init__(benchmark=benchmark, data_path=data_path, rng=rng,
+                                                                 **kwargs)
+
+
+class ProteinStructureOriginalBenchmark(_FCNetBaseOriginalBenchmark):
+
+    def __init__(self, data_path: Union[Path, str, None] = None,
+                 rng: Union[np.random.RandomState, int, None] = None, **kwargs):
+        from hpobench import config_file
+        data_path = Path(data_path) if data_path is not None else config_file.data_dir / 'fcnet_tabular_benchmarks'
+
+        from tabular_benchmarks import FCNetProteinStructureBenchmark
+        benchmark = FCNetProteinStructureBenchmark(data_dir=str(data_path))
+        super(ProteinStructureOriginalBenchmark, self).__init__(benchmark=benchmark, data_path=data_path, rng=rng,
+                                                                **kwargs)
+
+
+class NavalPropulsionOriginalBenchmark(_FCNetBaseOriginalBenchmark):
+
+    def __init__(self, data_path: Union[Path, str, None] = None,
+                 rng: Union[np.random.RandomState, int, None] = None, **kwargs):
+        from hpobench import config_file
+        data_path = Path(data_path) if data_path is not None else config_file.data_dir / 'fcnet_tabular_benchmarks'
+
+        from tabular_benchmarks import FCNetNavalPropulsionBenchmark
+        benchmark = FCNetNavalPropulsionBenchmark(data_dir=str(data_path))
+        super(NavalPropulsionOriginalBenchmark, self).__init__(benchmark=benchmark, data_path=data_path, rng=rng,
+                                                               **kwargs)
+
+
+class ParkinsonsTelemonitoringOriginalBenchmark(_FCNetBaseOriginalBenchmark):
+
+    def __init__(self, data_path: Union[Path, str, None] = None,
+                 rng: Union[np.random.RandomState, int, None] = None, **kwargs):
+        from hpobench import config_file
+        data_path = Path(data_path) if data_path is not None else config_file.data_dir / 'fcnet_tabular_benchmarks'
+
+        from tabular_benchmarks import FCNetParkinsonsTelemonitoringBenchmark
+        benchmark = FCNetParkinsonsTelemonitoringBenchmark(data_dir=str(data_path))
+        super(ParkinsonsTelemonitoringOriginalBenchmark, self).__init__(benchmark=benchmark, data_path=data_path,
+                                                                        rng=rng, **kwargs)
+
+
+__all__ = ["SliceLocalizationBenchmark", "SliceLocalizationOriginalBenchmark",
+           "ProteinStructureBenchmark", "ProteinStructureOriginalBenchmark",
+           "NavalPropulsionBenchmark", "NavalPropulsionOriginalBenchmark",
+           "ParkinsonsTelemonitoringBenchmark", "ParkinsonsTelemonitoringOriginalBenchmark"]

--- a/hpobench/benchmarks/rl/cartpole.py
+++ b/hpobench/benchmarks/rl/cartpole.py
@@ -1,6 +1,12 @@
 """
 Changelog:
 ==========
+0.0.4
+* Set the lower bound of the hp `likelihood_ratio_clipping` to a small number instead of 0.
+  The PPO agent does not accept a value of 0 here and will raise an error.
+* Pass the hp `entropy_regularization` to the agent.
+* Add the hp `entropy_regularization` to the ConfigSpace of the CartpoleFull Benchmark.
+
 0.0.3
 * New container release due to a general change in the communication between container and HPOBench.
   Works with HPOBench >= v0.0.8
@@ -30,7 +36,7 @@ from tensorforce.execution import Runner  # noqa: E402
 from hpobench.abstract_benchmark import AbstractBenchmark  # noqa: E402
 from hpobench.util import rng_helper  # noqa: E402
 
-__version__ = '0.0.3'
+__version__ = '0.0.4'
 
 logger = logging.getLogger('CartpoleBenchmark')
 tf.logging.set_verbosity(tf.logging.ERROR)
@@ -184,7 +190,8 @@ class CartpoleBase(AbstractBenchmark):
                                                                "learning_rate":
                                                                    configuration["baseline_learning_rate"]},
                                                  "num_steps": configuration["baseline_optimization_steps"]},
-                             likelihood_ratio_clipping=configuration["likelihood_ratio_clipping"]
+                             likelihood_ratio_clipping=configuration["likelihood_ratio_clipping"],
+                             entropy_regularization=configuration["entropy_regularization"],
                              )
 
             def episode_finished(record):
@@ -279,7 +286,8 @@ class CartpoleFull(CartpoleBase):
             CS.UniformIntegerHyperparameter("batch_size", lower=8, default_value=64, upper=256, log=True),
             CS.UniformFloatHyperparameter("learning_rate", lower=1e-7, default_value=1e-3, upper=1e-1, log=True),
             CS.UniformFloatHyperparameter("discount", lower=0, default_value=.99, upper=1),
-            CS.UniformFloatHyperparameter("likelihood_ratio_clipping", lower=0, default_value=.2, upper=1),
+            CS.UniformFloatHyperparameter("likelihood_ratio_clipping", lower=1e-7, default_value=.2, upper=1),
+            CS.UniformFloatHyperparameter("entropy_regularization", lower=0, default_value=0.01, upper=1),
             CS.CategoricalHyperparameter("activation_1", ["tanh", "relu"]),
             CS.CategoricalHyperparameter("activation_2", ["tanh", "relu"]),
             CS.CategoricalHyperparameter("optimizer_type", ["adam", "rmsprop"]),
@@ -327,8 +335,8 @@ class CartpoleReduced(CartpoleBase):
             CS.UniformIntegerHyperparameter("batch_size", lower=8, default_value=64, upper=256, log=True),
             CS.UniformFloatHyperparameter("learning_rate", lower=1e-7, default_value=1e-3, upper=1e-1, log=True),
             CS.UniformFloatHyperparameter("discount", lower=0, default_value=.99, upper=1),
-            CS.UniformFloatHyperparameter("likelihood_ratio_clipping", lower=0, default_value=.2, upper=1),
-            CS.UniformFloatHyperparameter("entropy_regularization", lower=0, default_value=0.01, upper=1)
+            CS.UniformFloatHyperparameter("likelihood_ratio_clipping", lower=1e-7, default_value=.2, upper=1),
+            CS.UniformFloatHyperparameter("entropy_regularization", lower=0, default_value=0.01, upper=1),
         ])
         return cs
 

--- a/hpobench/container/benchmarks/nas/nasbench_201.py
+++ b/hpobench/container/benchmarks/nas/nasbench_201.py
@@ -28,3 +28,35 @@ class ImageNetNasBench201Benchmark(AbstractBenchmarkClient):
         kwargs['container_name'] = kwargs.get('container_name', 'nasbench_201')
         kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(ImageNetNasBench201Benchmark, self).__init__(**kwargs)
+
+
+class Cifar10ValidNasBench201OriginalBenchmark(AbstractBenchmarkClient):
+    def __init__(self, **kwargs):
+        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'Cifar10ValidNasBench201OriginalBenchmark')
+        kwargs['container_name'] = kwargs.get('container_name', 'nasbench_201')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.5')
+        super(Cifar10ValidNasBench201OriginalBenchmark, self).__init__(**kwargs)
+
+
+class Cifar100NasBench201OriginalBenchmark(AbstractBenchmarkClient):
+    def __init__(self, **kwargs):
+        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'Cifar100NasBench201OriginalBenchmark')
+        kwargs['container_name'] = kwargs.get('container_name', 'nasbench_201')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.5')
+        super(Cifar100NasBench201OriginalBenchmark, self).__init__(**kwargs)
+
+
+class ImageNetNasBench201OriginalBenchmark(AbstractBenchmarkClient):
+    def __init__(self, **kwargs):
+        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ImageNetNasBench201OriginalBenchmark')
+        kwargs['container_name'] = kwargs.get('container_name', 'nasbench_201')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.5')
+        super(ImageNetNasBench201OriginalBenchmark, self).__init__(**kwargs)
+
+
+__all__ = ["Cifar10ValidNasBench201Benchmark",
+           "Cifar100NasBench201Benchmark",
+           "ImageNetNasBench201Benchmark",
+           "Cifar10ValidNasBench201OriginalBenchmark",
+           "Cifar100NasBench201OriginalBenchmark",
+           "ImageNetNasBench201OriginalBenchmark"]

--- a/hpobench/container/benchmarks/nas/nasbench_201.py
+++ b/hpobench/container/benchmarks/nas/nasbench_201.py
@@ -10,7 +10,7 @@ class Cifar10ValidNasBench201Benchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'Cifar10ValidNasBench201Benchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'nasbench_201')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.5')
         super(Cifar10ValidNasBench201Benchmark, self).__init__(**kwargs)
 
 
@@ -18,7 +18,7 @@ class Cifar100NasBench201Benchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'Cifar100NasBench201Benchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'nasbench_201')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.5')
         super(Cifar100NasBench201Benchmark, self).__init__(**kwargs)
 
 
@@ -26,37 +26,37 @@ class ImageNetNasBench201Benchmark(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ImageNetNasBench201Benchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'nasbench_201')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.5')
         super(ImageNetNasBench201Benchmark, self).__init__(**kwargs)
 
 
-class Cifar10ValidNasBench201OriginalBenchmark(AbstractBenchmarkClient):
+class Cifar10ValidNasBench201BenchmarkOriginal(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
-        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'Cifar10ValidNasBench201OriginalBenchmark')
+        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'Cifar10ValidNasBench201BenchmarkOriginal')
         kwargs['container_name'] = kwargs.get('container_name', 'nasbench_201')
         kwargs['latest'] = kwargs.get('container_tag', '0.0.5')
-        super(Cifar10ValidNasBench201OriginalBenchmark, self).__init__(**kwargs)
+        super(Cifar10ValidNasBench201BenchmarkOriginal, self).__init__(**kwargs)
 
 
-class Cifar100NasBench201OriginalBenchmark(AbstractBenchmarkClient):
+class Cifar100NasBench201BenchmarkOriginal(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
-        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'Cifar100NasBench201OriginalBenchmark')
+        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'Cifar100NasBench201BenchmarkOriginal')
         kwargs['container_name'] = kwargs.get('container_name', 'nasbench_201')
         kwargs['latest'] = kwargs.get('container_tag', '0.0.5')
-        super(Cifar100NasBench201OriginalBenchmark, self).__init__(**kwargs)
+        super(Cifar100NasBench201BenchmarkOriginal, self).__init__(**kwargs)
 
 
-class ImageNetNasBench201OriginalBenchmark(AbstractBenchmarkClient):
+class ImageNetNasBench201BenchmarkOriginal(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
-        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ImageNetNasBench201OriginalBenchmark')
+        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ImageNetNasBench201BenchmarkOriginal')
         kwargs['container_name'] = kwargs.get('container_name', 'nasbench_201')
         kwargs['latest'] = kwargs.get('container_tag', '0.0.5')
-        super(ImageNetNasBench201OriginalBenchmark, self).__init__(**kwargs)
+        super(ImageNetNasBench201BenchmarkOriginal, self).__init__(**kwargs)
 
 
 __all__ = ["Cifar10ValidNasBench201Benchmark",
            "Cifar100NasBench201Benchmark",
            "ImageNetNasBench201Benchmark",
-           "Cifar10ValidNasBench201OriginalBenchmark",
-           "Cifar100NasBench201OriginalBenchmark",
-           "ImageNetNasBench201OriginalBenchmark"]
+           "Cifar10ValidNasBench201BenchmarkOriginal",
+           "Cifar100NasBench201BenchmarkOriginal",
+           "ImageNetNasBench201BenchmarkOriginal"]

--- a/hpobench/container/benchmarks/nas/tabular_benchmarks.py
+++ b/hpobench/container/benchmarks/nas/tabular_benchmarks.py
@@ -42,43 +42,43 @@ class ParkinsonsTelemonitoringBenchmark(AbstractBenchmarkClient):
         super(ParkinsonsTelemonitoringBenchmark, self).__init__(**kwargs)
 
 
-class SliceLocalizationOriginalBenchmark(AbstractBenchmarkClient):
+class SliceLocalizationBenchmarkOriginal(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['data_path'] = '/home/fcnet_tabular_benchmarks'
-        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'SliceLocalizationOriginalBenchmark')
+        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'SliceLocalizationBenchmarkOriginal')
         kwargs['container_name'] = kwargs.get('container_name', 'tabular_benchmarks')
         kwargs['latest'] = kwargs.get('container_tag', '0.0.5')
-        super(SliceLocalizationOriginalBenchmark, self).__init__(**kwargs)
+        super(SliceLocalizationBenchmarkOriginal, self).__init__(**kwargs)
 
 
-class ProteinStructureOriginalBenchmark(AbstractBenchmarkClient):
+class ProteinStructureBenchmarkOriginal(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['data_path'] = '/home/fcnet_tabular_benchmarks'
-        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ProteinStructureOriginalBenchmark')
+        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ProteinStructureBenchmarkOriginal')
         kwargs['container_name'] = kwargs.get('container_name', 'tabular_benchmarks')
         kwargs['latest'] = kwargs.get('container_tag', '0.0.5')
-        super(ProteinStructureOriginalBenchmark, self).__init__(**kwargs)
+        super(ProteinStructureBenchmarkOriginal, self).__init__(**kwargs)
 
 
-class NavalPropulsionOriginalBenchmark(AbstractBenchmarkClient):
+class NavalPropulsionBenchmarkOriginal(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['data_path'] = '/home/fcnet_tabular_benchmarks'
-        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'NavalPropulsionOriginalBenchmark')
+        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'NavalPropulsionBenchmarkOriginal')
         kwargs['container_name'] = kwargs.get('container_name', 'tabular_benchmarks')
         kwargs['latest'] = kwargs.get('container_tag', '0.0.5')
-        super(NavalPropulsionOriginalBenchmark, self).__init__(**kwargs)
+        super(NavalPropulsionBenchmarkOriginal, self).__init__(**kwargs)
 
 
-class ParkinsonsTelemonitoringOriginalBenchmark(AbstractBenchmarkClient):
+class ParkinsonsTelemonitoringBenchmarkOriginal(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['data_path'] = '/home/fcnet_tabular_benchmarks'
-        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParkinsonsTelemonitoringOriginalBenchmark')
+        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParkinsonsTelemonitoringBenchmarkOriginal')
         kwargs['container_name'] = kwargs.get('container_name', 'tabular_benchmarks')
         kwargs['latest'] = kwargs.get('container_tag', '0.0.5')
-        super(ParkinsonsTelemonitoringOriginalBenchmark, self).__init__(**kwargs)
+        super(ParkinsonsTelemonitoringBenchmarkOriginal, self).__init__(**kwargs)
 
 
-__all__ = ["SliceLocalizationBenchmark", "SliceLocalizationOriginalBenchmark",
-           "ProteinStructureBenchmark", "ProteinStructureOriginalBenchmark",
-           "NavalPropulsionBenchmark", "NavalPropulsionOriginalBenchmark",
-           "ParkinsonsTelemonitoringBenchmark", "ParkinsonsTelemonitoringOriginalBenchmark"]
+__all__ = ["SliceLocalizationBenchmark", "SliceLocalizationBenchmarkOriginal",
+           "ProteinStructureBenchmark", "ProteinStructureBenchmarkOriginal",
+           "NavalPropulsionBenchmark", "NavalPropulsionBenchmarkOriginal",
+           "ParkinsonsTelemonitoringBenchmark", "ParkinsonsTelemonitoringBenchmarkOriginal"]

--- a/hpobench/container/benchmarks/nas/tabular_benchmarks.py
+++ b/hpobench/container/benchmarks/nas/tabular_benchmarks.py
@@ -11,7 +11,7 @@ class SliceLocalizationBenchmark(AbstractBenchmarkClient):
         kwargs['data_path'] = '/home/fcnet_tabular_benchmarks'
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'SliceLocalizationBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'tabular_benchmarks')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.5')
         super(SliceLocalizationBenchmark, self).__init__(**kwargs)
 
 
@@ -20,7 +20,7 @@ class ProteinStructureBenchmark(AbstractBenchmarkClient):
         kwargs['data_path'] = '/home/fcnet_tabular_benchmarks'
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ProteinStructureBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'tabular_benchmarks')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.5')
         super(ProteinStructureBenchmark, self).__init__(**kwargs)
 
 
@@ -29,7 +29,7 @@ class NavalPropulsionBenchmark(AbstractBenchmarkClient):
         kwargs['data_path'] = '/home/fcnet_tabular_benchmarks'
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'NavalPropulsionBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'tabular_benchmarks')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.5')
         super(NavalPropulsionBenchmark, self).__init__(**kwargs)
 
 
@@ -38,5 +38,47 @@ class ParkinsonsTelemonitoringBenchmark(AbstractBenchmarkClient):
         kwargs['data_path'] = '/home/fcnet_tabular_benchmarks'
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParkinsonsTelemonitoringBenchmark')
         kwargs['container_name'] = kwargs.get('container_name', 'tabular_benchmarks')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.5')
         super(ParkinsonsTelemonitoringBenchmark, self).__init__(**kwargs)
+
+
+class SliceLocalizationOriginalBenchmark(AbstractBenchmarkClient):
+    def __init__(self, **kwargs):
+        kwargs['data_path'] = '/home/fcnet_tabular_benchmarks'
+        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'SliceLocalizationOriginalBenchmark')
+        kwargs['container_name'] = kwargs.get('container_name', 'tabular_benchmarks')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.5')
+        super(SliceLocalizationOriginalBenchmark, self).__init__(**kwargs)
+
+
+class ProteinStructureOriginalBenchmark(AbstractBenchmarkClient):
+    def __init__(self, **kwargs):
+        kwargs['data_path'] = '/home/fcnet_tabular_benchmarks'
+        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ProteinStructureOriginalBenchmark')
+        kwargs['container_name'] = kwargs.get('container_name', 'tabular_benchmarks')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.5')
+        super(ProteinStructureOriginalBenchmark, self).__init__(**kwargs)
+
+
+class NavalPropulsionOriginalBenchmark(AbstractBenchmarkClient):
+    def __init__(self, **kwargs):
+        kwargs['data_path'] = '/home/fcnet_tabular_benchmarks'
+        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'NavalPropulsionOriginalBenchmark')
+        kwargs['container_name'] = kwargs.get('container_name', 'tabular_benchmarks')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.5')
+        super(NavalPropulsionOriginalBenchmark, self).__init__(**kwargs)
+
+
+class ParkinsonsTelemonitoringOriginalBenchmark(AbstractBenchmarkClient):
+    def __init__(self, **kwargs):
+        kwargs['data_path'] = '/home/fcnet_tabular_benchmarks'
+        kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'ParkinsonsTelemonitoringOriginalBenchmark')
+        kwargs['container_name'] = kwargs.get('container_name', 'tabular_benchmarks')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.5')
+        super(ParkinsonsTelemonitoringOriginalBenchmark, self).__init__(**kwargs)
+
+
+__all__ = ["SliceLocalizationBenchmark", "SliceLocalizationOriginalBenchmark",
+           "ProteinStructureBenchmark", "ProteinStructureOriginalBenchmark",
+           "NavalPropulsionBenchmark", "NavalPropulsionOriginalBenchmark",
+           "ParkinsonsTelemonitoringBenchmark", "ParkinsonsTelemonitoringOriginalBenchmark"]

--- a/hpobench/container/benchmarks/rl/cartpole.py
+++ b/hpobench/container/benchmarks/rl/cartpole.py
@@ -10,7 +10,7 @@ class CartpoleReduced(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'CartpoleReduced')
         kwargs['container_name'] = kwargs.get('container_name', 'cartpole')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(CartpoleReduced, self).__init__(**kwargs)
 
 
@@ -18,5 +18,5 @@ class CartpoleFull(AbstractBenchmarkClient):
     def __init__(self, **kwargs):
         kwargs['benchmark_name'] = kwargs.get('benchmark_name', 'CartpoleFull')
         kwargs['container_name'] = kwargs.get('container_name', 'cartpole')
-        kwargs['latest'] = kwargs.get('container_tag', '0.0.3')
+        kwargs['latest'] = kwargs.get('container_tag', '0.0.4')
         super(CartpoleFull, self).__init__(**kwargs)

--- a/tests/test_tabular_benchmarks.py
+++ b/tests/test_tabular_benchmarks.py
@@ -15,7 +15,6 @@ from hpobench.container.benchmarks.nas.tabular_benchmarks import SliceLocalizati
 class TestTabularBenchmark(unittest.TestCase):
     def setUp(self) -> None:
         self.benchmark = SliceLocalizationBenchmark(
-            container_source='/media/philipp/Volume/Code/Container/new_container/tabular_benchmarks',
             rng=1,
             )
         self.default_config = self.benchmark.get_configuration_space(seed=1).get_default_configuration()
@@ -97,7 +96,7 @@ class TestTabularBenchmark(unittest.TestCase):
         assert runtimes == pytest.approx(runtime, abs=0.0001)
 
     def test_protein_benchmark(self):
-        default_config = self.setUp()
+        default_config = self.default_config
 
         benchmark = ProteinStructureBenchmark(
             socket_id=self.socket_id
@@ -120,7 +119,7 @@ class TestTabularBenchmark(unittest.TestCase):
         assert calculated_runtime == pytest.approx(runtime, abs=0.0001)
 
     def test_parkinson_benchmark(self):
-        default_config = self.socket_id
+        default_config = self.default_config
 
         benchmark = ParkinsonsTelemonitoringBenchmark(
             socket_id=self.socket_id

--- a/tests/test_tabular_benchmarks.py
+++ b/tests/test_tabular_benchmarks.py
@@ -55,7 +55,7 @@ class TestTabularBenchmark(unittest.TestCase):
         default_config = self.default_config
 
         benchmark = SliceLocalizationBenchmark(
-            socket_id=self.socket_id
+            rng=1,
         )
         result = benchmark.objective_function(configuration=default_config, fidelity=dict(budget=1),
                                               run_index=[0, 1, 2, 3])
@@ -77,7 +77,7 @@ class TestTabularBenchmark(unittest.TestCase):
         default_config = self.default_config
 
         benchmark = NavalPropulsionBenchmark(
-            socket_id=self.socket_id
+            rng=1,
         )
         result = benchmark.objective_function(configuration=default_config, fidelity=dict(budget=1),
                                               run_index=[0, 1, 2, 3])
@@ -99,7 +99,7 @@ class TestTabularBenchmark(unittest.TestCase):
         default_config = self.default_config
 
         benchmark = ProteinStructureBenchmark(
-            socket_id=self.socket_id
+            rng=1,
         )
         result = benchmark.objective_function(configuration=default_config, fidelity=dict(budget=1),
                                               run_index=[0, 1, 2, 3])
@@ -122,7 +122,7 @@ class TestTabularBenchmark(unittest.TestCase):
         default_config = self.default_config
 
         benchmark = ParkinsonsTelemonitoringBenchmark(
-            socket_id=self.socket_id
+            rng=1,
         )
         result = benchmark.objective_function(configuration=default_config, fidelity=dict(budget=1),
                                               run_index=[0, 1, 2, 3])

--- a/tests/test_tabular_benchmarks.py
+++ b/tests/test_tabular_benchmarks.py
@@ -1,5 +1,5 @@
 import logging
-
+import unittest
 import pytest
 
 logging.basicConfig(level=logging.DEBUG)
@@ -12,122 +12,130 @@ from hpobench.container.benchmarks.nas.tabular_benchmarks import SliceLocalizati
     NavalPropulsionBenchmark, ParkinsonsTelemonitoringBenchmark, ProteinStructureBenchmark
 
 
-def setup():
-    benchmark = SliceLocalizationBenchmark()
-    default_config = benchmark.get_configuration_space(seed=1).get_default_configuration()
-    return default_config
+class TestTabularBenchmark(unittest.TestCase):
+    def setUp(self) -> None:
+        self.benchmark = SliceLocalizationBenchmark(
+            container_source='/media/philipp/Volume/Code/Container/new_container/tabular_benchmarks',
+            rng=1,
+            )
+        self.default_config = self.benchmark.get_configuration_space(seed=1).get_default_configuration()
+        self.socket_id = self.benchmark.socket_id
 
+    def test_tabular_benchmark_wrong_input(self):
+        default_config = self.default_config
 
-def test_tabular_benchmark_wrong_input():
-    default_config = setup()
-    benchmark = SliceLocalizationBenchmark(rng=1)
+        benchmark = SliceLocalizationBenchmark(
+            socket_id=self.socket_id
+        )
 
-    with pytest.raises(ValueError):
-        benchmark.objective_function(configuration=default_config, fidelity=dict(budget=0))
+        with pytest.raises(ValueError):
+            benchmark.objective_function(configuration=default_config, fidelity=dict(budget=0))
 
-    with pytest.raises(ValueError):
-        benchmark.objective_function(configuration=default_config, fidelity=dict(budget=1), run_index=0.1)
+        with pytest.raises(ValueError):
+            benchmark.objective_function(configuration=default_config, fidelity=dict(budget=1), run_index=0.1)
 
-    with pytest.raises(AssertionError):
-        benchmark.objective_function(configuration=default_config, fidelity=dict(budget=1), run_index=[4])
+        with pytest.raises(AssertionError):
+            benchmark.objective_function(configuration=default_config, fidelity=dict(budget=1), run_index=[4])
 
-    with pytest.raises(AssertionError):
-        benchmark.objective_function(configuration=default_config, fidelity=dict(budget=1), run_index=[])
+        with pytest.raises(AssertionError):
+            benchmark.objective_function(configuration=default_config, fidelity=dict(budget=1), run_index=[])
 
-    with pytest.raises(AssertionError):
-        benchmark.objective_function(configuration=default_config, fidelity=dict(budget=1), run_index=-1)
+        with pytest.raises(AssertionError):
+            benchmark.objective_function(configuration=default_config, fidelity=dict(budget=1), run_index=-1)
 
-    with pytest.raises(AssertionError):
-        benchmark.objective_function(configuration=default_config, fidelity=dict(budget=1), run_index=4)
+        with pytest.raises(AssertionError):
+            benchmark.objective_function(configuration=default_config, fidelity=dict(budget=1), run_index=4)
 
-    with pytest.raises(ValueError):
-        benchmark.objective_function(configuration=default_config, fidelity=dict(budget=101), run_index=3)
+        with pytest.raises(ValueError):
+            benchmark.objective_function(configuration=default_config, fidelity=dict(budget=101), run_index=3)
 
-    with pytest.raises((AssertionError, ValueError)):
-        benchmark.objective_function_test(configuration=default_config, fidelity=dict(budget=107))
+        with pytest.raises((AssertionError, ValueError)):
+            benchmark.objective_function_test(configuration=default_config, fidelity=dict(budget=107))
 
-    benchmark = None
+    def test_slice_benchmark(self):
+        default_config = self.default_config
 
+        benchmark = SliceLocalizationBenchmark(
+            socket_id=self.socket_id
+        )
+        result = benchmark.objective_function(configuration=default_config, fidelity=dict(budget=1),
+                                              run_index=[0, 1, 2, 3])
 
-def test_slice_benchmark():
-    default_config = setup()
+        mean = 0.01828
+        assert result['function_value'] == pytest.approx(mean, abs=0.0001)
 
-    benchmark = SliceLocalizationBenchmark(rng=1)
-    result = benchmark.objective_function(configuration=default_config, fidelity=dict(budget=1), run_index=[0, 1, 2, 3])
+        runs = result['info']['valid_rmse_per_run']
+        calculated_mean = sum(runs) / len(runs)
+        assert calculated_mean == pytest.approx(mean, abs=0.0001)
 
-    mean = 0.01828
-    assert result['function_value'] == pytest.approx(mean, abs=0.0001)
+        runtime = 23.1000
+        assert result['cost'] == pytest.approx(runtime, abs=0.0001)
 
-    runs = result['info']['valid_rmse_per_run']
-    calculated_mean = sum(runs) / len(runs)
-    assert calculated_mean == pytest.approx(mean, abs=0.0001)
+        runtimes = sum(result['info']['runtime_per_run'])
+        assert runtimes == pytest.approx(runtime, abs=0.0001)
 
-    runtime = 23.1000
-    assert result['cost'] == pytest.approx(runtime, abs=0.0001)
+    def test_naval_benchmark(self):
+        default_config = self.default_config
 
-    runtimes = sum(result['info']['runtime_per_run'])
-    assert runtimes == pytest.approx(runtime, abs=0.0001)
-    benchmark = None
+        benchmark = NavalPropulsionBenchmark(
+            socket_id=self.socket_id
+        )
+        result = benchmark.objective_function(configuration=default_config, fidelity=dict(budget=1),
+                                              run_index=[0, 1, 2, 3])
 
+        mean = 0.8928
+        assert result['function_value'] == pytest.approx(mean, abs=0.0001)
 
-def test_naval_benchmark():
-    default_config = setup()
+        runs = result['info']['valid_rmse_per_run']
+        calculated_mean = sum(runs) / len(runs)
+        assert calculated_mean == pytest.approx(mean, abs=0.0001)
 
-    benchmark = NavalPropulsionBenchmark(rng=1)
-    result = benchmark.objective_function(configuration=default_config, fidelity=dict(budget=1), run_index=[0, 1, 2, 3])
+        runtime = 5.2477
+        assert result['cost'] == pytest.approx(runtime, abs=0.0001)
 
-    mean = 0.8928
-    assert result['function_value'] == pytest.approx(mean, abs=0.0001)
+        runtimes = sum(result['info']['runtime_per_run'])
+        assert runtimes == pytest.approx(runtime, abs=0.0001)
 
-    runs = result['info']['valid_rmse_per_run']
-    calculated_mean = sum(runs) / len(runs)
-    assert calculated_mean == pytest.approx(mean, abs=0.0001)
+    def test_protein_benchmark(self):
+        default_config = self.setUp()
 
-    runtime = 5.2477
-    assert result['cost'] == pytest.approx(runtime, abs=0.0001)
+        benchmark = ProteinStructureBenchmark(
+            socket_id=self.socket_id
+        )
+        result = benchmark.objective_function(configuration=default_config, fidelity=dict(budget=1),
+                                              run_index=[0, 1, 2, 3])
 
-    runtimes = sum(result['info']['runtime_per_run'])
-    assert runtimes == pytest.approx(runtime, abs=0.0001)
-    benchmark = None
+        mean = 0.4474
+        assert result['function_value'] == pytest.approx(mean, abs=0.0001)
 
+        runs = result['info']['valid_rmse_per_run']
+        calculated_mean = sum(runs) / len(runs)
+        assert calculated_mean == pytest.approx(mean, abs=0.0001)
 
-def test_protein_benchmark():
-    default_config = setup()
+        runtime = 19.24213
+        assert result['cost'] == pytest.approx(runtime, abs=0.0001)
 
-    benchmark = ProteinStructureBenchmark(rng=1)
-    result = benchmark.objective_function(configuration=default_config, fidelity=dict(budget=1), run_index=[0, 1, 2, 3])
+        runtimes = result['info']['runtime_per_run']
+        calculated_runtime = sum(runtimes)
+        assert calculated_runtime == pytest.approx(runtime, abs=0.0001)
 
-    mean = 0.4474
-    assert result['function_value'] == pytest.approx(mean, abs=0.0001)
+    def test_parkinson_benchmark(self):
+        default_config = self.socket_id
 
-    runs = result['info']['valid_rmse_per_run']
-    calculated_mean = sum(runs) / len(runs)
-    assert calculated_mean == pytest.approx(mean, abs=0.0001)
+        benchmark = ParkinsonsTelemonitoringBenchmark(
+            socket_id=self.socket_id
+        )
+        result = benchmark.objective_function(configuration=default_config, fidelity=dict(budget=1),
+                                              run_index=[0, 1, 2, 3])
 
-    runtime = 19.24213
-    assert result['cost'] == pytest.approx(runtime, abs=0.0001)
+        mean = 0.7425
+        assert result['function_value'] == pytest.approx(mean, abs=0.0001)
 
-    runtimes = result['info']['runtime_per_run']
-    calculated_runtime = sum(runtimes)
-    assert calculated_runtime == pytest.approx(runtime, abs=0.0001)
-    benchmark = None
+        with pytest.raises(AssertionError):
+            benchmark.objective_function_test(default_config, fidelity=dict(budget=1, ))
 
+        result = benchmark.objective_function_test(configuration=default_config, fidelity=dict(budget=100))
+        assert pytest.approx(0.15010187, result['function_value'], abs=0.001)
 
-def test_parkinson_benchmark():
-    default_config = setup()
-
-    benchmark = ParkinsonsTelemonitoringBenchmark(rng=1)
-    result = benchmark.objective_function(configuration=default_config, fidelity=dict(budget=1), run_index=[0, 1, 2, 3])
-
-    mean = 0.7425
-    assert result['function_value'] == pytest.approx(mean, abs=0.0001)
-
-    with pytest.raises(AssertionError):
-        benchmark.objective_function_test(default_config, fidelity=dict(budget=1,))
-
-    result = benchmark.objective_function_test(configuration=default_config, fidelity=dict(budget=100))
-    assert pytest.approx(0.15010187, result['function_value'], abs=0.001)
-
-    runtime = 62.7268
-    assert result['cost'] == pytest.approx(runtime, abs=0.0001)
-    benchmark = None
+        runtime = 62.7268
+        assert result['cost'] == pytest.approx(runtime, abs=0.0001)


### PR DESCRIPTION
The base benchmark offers access to the entire data set. 
However, we add a new fidelity space to those benchmarks to make it comparable to the experiments in the [DEHB](https://github.com/automl/DEHB/tree/937dd5cf48e79f6d587ea2ff408cb5ad9a8dce46/dehb/examples) paper