### PR TITLE
Implement AbstractMultiObjectiveBenchmark.

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,10 +11,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: 3.6
-            DISPLAY_NAME: "Singularity Tests"
-            RUN_TESTS: true
-            USE_SINGULARITY: true
           - python-version: 3.7
             DISPLAY_NAME: "Singularity Tests + CODECOV"
             RUN_TESTS: true

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,6 @@
 # 0.0.11
+  * Drop Support for 3.6:
+    Although most of the functionality should still work, we drop the official support for 3.6.
 
 # 0.0.10
   * Cartpole Benchmark Version 0.0.4:

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 # 0.0.11
   * Drop Support for 3.6:
     Although most of the functionality should still work, we drop the official support for 3.6.
+  * Add an interface for Multi-Objective Benchmarks.
+  * Add a check for the return values of the objective_functions
+    The returned dictionary of the objective functions have to fulfill now some criteria. 
 
 # 0.0.10
   * Cartpole Benchmark Version 0.0.4:

--- a/hpobench/abstract_benchmark.py
+++ b/hpobench/abstract_benchmark.py
@@ -251,3 +251,73 @@ class AbstractBenchmark(abc.ABC, metaclass=abc.ABCMeta):
 
         """
         raise NotImplementedError()
+
+
+class AbstractMultiObjectiveBenchmark(AbstractBenchmark):
+    """
+    Abstract Benchmark class for multi-objective benchmarks.
+    The only purpose of this class is to point out to users that this benchmark returns multiple
+    objective function values.
+
+    When writing a benchmark, please make sure to inherit from the correct abstract class.
+    """
+    @abc.abstractmethod
+    def objective_function(self, configuration: Union[ConfigSpace.Configuration, Dict],
+                           fidelity: Union[Dict, ConfigSpace.Configuration, None] = None,
+                           rng: Union[np.random.RandomState, int, None] = None,
+                           **kwargs) -> Dict:
+        """
+        Objective function.
+
+        Override this function to provide your multi-objective benchmark function. This
+        function will be called by one of the evaluate functions. For
+        flexibility, you have to return a dictionary with the only mandatory
+        key being `function_values`, the objective function values for the
+        `configuration` which was passed. By convention, all benchmarks are
+        minimization problems.
+
+        `function_value` is a dictionary that contains all available criteria.
+
+        Parameters
+        ----------
+        configuration : Dict
+        fidelity: Dict, None
+            Fidelity parameters, check get_fidelity_space(). Uses default (max) value if None.
+        rng : np.random.RandomState, int, None
+            It might be useful to pass a `rng` argument to the function call to
+            bypass the default "seed" generator. Only using the default random
+            state (`self.rng`) could lead to an overfitting towards the
+            `self.rng`'s seed.
+
+        Returns
+        -------
+        Dict
+            Must contain at least the key `function_value` and `cost`.
+            Note that `function_value` should be a Dict here.
+        """
+        NotImplementedError()
+
+    @abc.abstractmethod
+    def objective_function_test(self, configuration: Union[ConfigSpace.Configuration, Dict],
+                                fidelity: Union[Dict, ConfigSpace.Configuration, None] = None,
+                                rng: Union[np.random.RandomState, int, None] = None,
+                                **kwargs) -> Dict:
+        """
+        If there is a different objective function for offline testing, e.g
+        testing a machine learning on a hold extra test set instead
+        on a validation set override this function here.
+
+        Parameters
+        ----------
+        configuration : Dict
+        fidelity: Dict, None
+            Fidelity parameters, check get_fidelity_space(). Uses default (max) value if None.
+        rng : np.random.RandomState, int, None
+            see :py:func:`~HPOBench.abstract_benchmark.objective_function`
+
+        Returns
+        -------
+        Dict
+            Must contain at least the key `function_value` and `cost`.
+        """
+        NotImplementedError()

--- a/hpobench/abstract_benchmark.py
+++ b/hpobench/abstract_benchmark.py
@@ -311,7 +311,7 @@ class AbstractMultiObjectiveBenchmark(AbstractBenchmark):
             Must contain at least the key `function_value` and `cost`.
             Note that `function_value` should be a Dict here.
         """
-        NotImplementedError()
+        raise NotImplementedError()
 
     @abc.abstractmethod
     def objective_function_test(self, configuration: Union[ConfigSpace.Configuration, Dict],
@@ -336,7 +336,7 @@ class AbstractMultiObjectiveBenchmark(AbstractBenchmark):
         Dict
             Must contain at least the key `function_value` and `cost`.
         """
-        NotImplementedError()
+        raise NotImplementedError()
 
     @staticmethod
     def _check_return_values(return_values: Dict) -> Dict:
@@ -355,4 +355,4 @@ class AbstractMultiObjectiveBenchmark(AbstractBenchmark):
         """
         Return the names of supported targets
         """
-        NotImplementedError()
+        raise NotImplementedError()

--- a/hpobench/abstract_benchmark.py
+++ b/hpobench/abstract_benchmark.py
@@ -126,7 +126,11 @@ class AbstractBenchmark(abc.ABC, metaclass=abc.ABCMeta):
             # All benchmarks should work on dictionaries. Cast the both objects to dictionaries.
             return_values = wrapped_function(self, configuration.get_dictionary(), fidelity.get_dictionary(), **kwargs)
 
-            return_values = AbstractBenchmark._check_return_values(return_values)
+            # Make sure that every benchmark returns a well-shaped return object.
+            # Every benchmark have to have the fields 'function_value' and 'cost'.
+            # Multi-Objective benchmarks have to return collections of values for the 'function_value' field.
+            return_values = type(self)._check_return_values(return_values)
+            return return_values
         return wrapper
 
     @staticmethod

--- a/hpobench/benchmarks/od/od_ae.py
+++ b/hpobench/benchmarks/od/od_ae.py
@@ -407,6 +407,7 @@ class ODAutoencoder(AbstractBenchmark):
 
         return fidel_space
 
+    # pylint: disable=arguments-differ
     def get_meta_information(self):
         """ Returns the meta information for the benchmark """
         X_train, _ = self.datamanager.dataset.get_train_data()

--- a/hpobench/dependencies/ml/ml_benchmark_template.py
+++ b/hpobench/dependencies/ml/ml_benchmark_template.py
@@ -102,6 +102,7 @@ class MLBenchmark(AbstractBenchmark):
         """
         raise NotImplementedError()
 
+    # pylint: disable=arguments-differ
     def get_meta_information(self):
         """ Returns the meta information for the benchmark """
         return {

--- a/hpobench/dependencies/od/traditional_benchmark.py
+++ b/hpobench/dependencies/od/traditional_benchmark.py
@@ -214,6 +214,7 @@ class ODTraditional(AbstractBenchmark):
         fidel_space = CS.ConfigurationSpace(seed=seed)
         return fidel_space
 
+    # pylint: disable=arguments-differ
     def get_meta_information(self):
         """ Returns the meta information for the benchmark """
         X_train, y_train = self.datamanager.dataset.get_train_data()

--- a/tests/test_abstract_benchmark.py
+++ b/tests/test_abstract_benchmark.py
@@ -2,14 +2,16 @@ import pytest
 
 from hpobench.abstract_benchmark import AbstractBenchmark, AbstractMultiObjectiveBenchmark
 
-with pytest.raises(NotImplementedError):
-    AbstractBenchmark.get_configuration_space()
 
-with pytest.raises(NotImplementedError):
-    AbstractBenchmark.get_fidelity_space()
+def test_abstract_benchmark():
+    with pytest.raises(NotImplementedError):
+        AbstractBenchmark.get_configuration_space()
 
-with pytest.raises(NotImplementedError):
-    AbstractBenchmark.get_meta_information()
+    with pytest.raises(NotImplementedError):
+        AbstractBenchmark.get_fidelity_space()
 
-with pytest.raises(NotImplementedError):
-    AbstractMultiObjectiveBenchmark.get_objective_names()
+    with pytest.raises(NotImplementedError):
+        AbstractBenchmark.get_meta_information()
+
+    with pytest.raises(NotImplementedError):
+        AbstractMultiObjectiveBenchmark.get_objective_names()

--- a/tests/test_abstract_benchmark.py
+++ b/tests/test_abstract_benchmark.py
@@ -1,6 +1,6 @@
 import pytest
 
-from hpobench.abstract_benchmark import AbstractBenchmark
+from hpobench.abstract_benchmark import AbstractBenchmark, AbstractMultiObjectiveBenchmark
 
 with pytest.raises(NotImplementedError):
     AbstractBenchmark.get_configuration_space()
@@ -10,3 +10,6 @@ with pytest.raises(NotImplementedError):
 
 with pytest.raises(NotImplementedError):
     AbstractBenchmark.get_meta_information()
+
+with pytest.raises(NotImplementedError):
+    AbstractMultiObjectiveBenchmark.get_objective_names()

--- a/tests/test_nasbench_201.py
+++ b/tests/test_nasbench_201.py
@@ -84,10 +84,11 @@ def test_nasbench201_config():
     func = Cifar10ValidNasBench201Benchmark.config_to_structure_func(4)
     struct = func(c)
 
-    assert struct.__repr__() == '_Structure(4 nodes with |avg_pool_3x3~0|+|none~0|nor_conv_3x3~1|+' \
-                                '|nor_conv_3x3~0|nor_conv_3x3~1|skip_connect~2|)'
+    assert struct.__repr__() == '_Structure(4 nodes with |nor_conv_1x1~0|+|nor_conv_3x3~0|nor_conv_3x3~1|+' \
+                                '|nor_conv_1x1~0|nor_conv_1x1~1|nor_conv_3x3~2|)'
     assert len(struct) == 4
-    assert struct[0] == (('avg_pool_3x3', 0),)
+    assert struct[0] == (('nor_conv_1x1', 0),)
 
     struct_str = struct.tostr()
-    assert struct_str == '|avg_pool_3x3~0|+|none~0|nor_conv_3x3~1|+|nor_conv_3x3~0|nor_conv_3x3~1|skip_connect~2|'
+    assert struct_str == '|nor_conv_1x1~0|+|nor_conv_3x3~0|nor_conv_3x3~1|+' \
+                         '|nor_conv_1x1~0|nor_conv_1x1~1|nor_conv_3x3~2|'

--- a/tests/test_od.py
+++ b/tests/test_od.py
@@ -14,17 +14,16 @@ def test_ocsvm():
 
 
 def test_kde():
-    from hpobench.container.benchmarks.od.od_benchmarks import  ODKernelDensityEstimation
+    from hpobench.container.benchmarks.od.od_benchmarks import ODKernelDensityEstimation
     seed = 6
     benchmark = ODKernelDensityEstimation("cardio", rng=seed)
 
     config = benchmark.get_configuration_space(seed=seed).sample_configuration()
-    result = benchmark.objective_function_test(configuration=config, rng=seed)
-    print(config['kernel'], config['bandwidth'], result['function_value'])
+    assert config is not None
 
-    assert config['kernel'] == "exponential"
-    assert config['bandwidth'] == pytest.approx(15.2274, abs=0.001)
-    assert result['function_value'] == pytest.approx(0.14409, abs=0.0001)
+    test_config = {'bandwidth': 15.227439996058147, 'kernel': 'tophat', 'scaler': 'Standard'}
+    result = benchmark.objective_function_test(configuration=test_config, rng=seed)
+    assert result['function_value'] == pytest.approx(0.8675, abs=0.0001)
 
 
 def test_ae():
@@ -33,8 +32,13 @@ def test_ae():
     benchmark = ODAutoencoder("cardio", rng=seed)
 
     config = benchmark.get_configuration_space(seed=seed).sample_configuration()
-    result = benchmark.objective_function(configuration=config, rng=seed)
-    print(config['dropout_rate'], result['function_value'])
+    assert config is not None
 
-    assert config['dropout_rate'] == pytest.approx(0.69512, abs=0.00001)
-    assert result['function_value'] == pytest.approx(0.2833, abs=0.0001)
+    test_config = {'activation': 'tanh', 'batch_normalization': True,
+                   'batch_size': 424, 'beta1': 0.8562127972330622, 'beta2': 0.9107549023256032,
+                   'dropout': False, 'lr': 0.0013160410886450579, 'num_latent_units': 5,
+                   'num_layers': 1, 'scaler': 'MinMax', 'skip_connection': True,
+                   'weight_decay': 0.07358821063486902, 'num_units_layer_1': 16}
+
+    result = benchmark.objective_function(configuration=test_config, rng=seed)
+    assert result['function_value'] == pytest.approx(0.81378, abs=0.001)

--- a/tests/test_tabular_benchmarks.py
+++ b/tests/test_tabular_benchmarks.py
@@ -134,7 +134,7 @@ class TestTabularBenchmark(unittest.TestCase):
             benchmark.objective_function_test(default_config, fidelity=dict(budget=1, ))
 
         result = benchmark.objective_function_test(configuration=default_config, fidelity=dict(budget=100))
-        assert pytest.approx(0.15010187, result['function_value'], abs=0.001)
+        assert result['function_value'] == pytest.approx(0.15010187, abs=0.001)
 
         runtime = 62.7268
         assert result['cost'] == pytest.approx(runtime, abs=0.0001)


### PR DESCRIPTION
It basically does nothing. 
It just points out to the user that this is a MO benchmark.
@KEggensperger: What do you think, do we really need that? 
Or should I implement some "check" before returning the result_dict that `function_value` is a dict?